### PR TITLE
Test value transfer greater than 64 bits

### DIFF
--- a/src/GeneralStateTestsFiller/stEWASMTests/callValueExceeds64bitFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/callValueExceeds64bitFiller.yml
@@ -1,0 +1,94 @@
+callValueExceeds64bit:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    deadbeef00000000000000000000000000000000:
+      balance: '0xffff'
+      nonce: ''
+      storage: {}
+      code: |
+        (module
+          (import "ethereum" "call" (func $call (param i64 i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "getBalance"  (func $getBalance (param i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "getAddress" (func $getAddress (param i32)))
+          (memory 1 )
+          (data (i32.const 0)  "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (data (i32.const 20) "\00\00\00\00\00\00\00\00\00\ff\ff\ff\ff\ff\ff\ff\ff\ff\ff\ff")
+          (data (i32.const 52) "\42\04\20\42\04\20\42\00")
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+          (func $main
+            ;; Memory layout:
+            ;;   0 -  20 bytes: address (4)
+            ;;  20 -  52 bytes: value (0)
+            ;;  52 -  56 bytes: data (0x42004200)
+            ;;  56 -  60 bytes: result
+            (i32.store (i32.const 56) ;; store the result so it is not returned
+            ;;          gas              addrOffset    valOffset      dataOffset     dataLength
+              (call $call (i64.const 200000) (i32.const 0) (i32.const 20) (i32.const 52) (i32.const 4)))
+            ;;drop
+          )
+        )
+    deadbeef00000000000000000000000000000001:
+      balance: '0xfffffffffffffffffffffffffffff'
+      nonce: ''
+      storage: {}
+      code: |
+        (module
+          (import "ethereum" "call" (func $call (param i64 i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "getBalance"  (func $getBalance (param i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "getAddress" (func $getAddress (param i32)))
+          (memory 1 )
+          (data (i32.const 0)  "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (data (i32.const 20) "\00\00\00\00\00\00\00\00\00\ff\ff\ff\ff\ff\ff\ff\ff\ff\ff\ff")
+          (data (i32.const 52) "\42\04\20\42\04\20\42\00")
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+          (func $main
+            ;; Memory layout:
+            ;;   0 -  20 bytes: address (4)
+            ;;  20 -  52 bytes: value (0)
+            ;;  52 -  56 bytes: data (0x42004200)
+            ;;  56 -  60 bytes: result
+            (i32.store (i32.const 56) ;; store the result so it is not returned
+            ;;          gas              addrOffset    valOffset      dataOffset     dataLength
+              (call $call (i64.const 200000) (i32.const 0) (i32.const 20) (i32.const 52) (i32.const 4)))
+            ;;drop
+          )
+        )
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # InitialBalance - contract1.call - valueTransfer - txCost - contract2.calldatasize - contract2.sstore
+        # 100000000000   - 700            - 9000          - 21000  - 2                      - 20000            = 99999949298
+        deadbeef00000000000000000000000000000000:
+          storage: {
+            56: '0x2'
+          }
+        deadbeef00000000000000000000000000000001:
+          storage: {
+            56: '0x4'
+          }
+  transaction:
+    data:
+    - '0x'
+    gasLimit:
+    - '0x6acfc0'
+    gasPrice: '0x01'
+    nonce: '0x04'
+    secretKey: "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    to: 'deadbeef00000000000000000000000000000000'
+    value:
+    - '0'


### PR DESCRIPTION
@ewasm/testing I have no idea what i'm doing but this should test that `ensureCondition` in Hera works for values greater than 64 bits.

0xdeadbeef....00 should fail and 0xdeadbeef....01 should succeed.

This should be tested on ewasm/hera#247

Fixes #42.