### PR TITLE
Non-controversial updates to memory tests

### DIFF
--- a/GeneralStateTests/stEWASMTests/codeCopy.json
+++ b/GeneralStateTests/stEWASMTests/codeCopy.json
@@ -2,10 +2,10 @@
     "codeCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "cpp-1.3.0+commit.883607f8.Darwin.appleclang",
-            "lllcversion" : "Version: 0.4.20-develop.2018.1.2+commit.efc198d5.Darwin.appleclang",
+            "filledwith" : "testeth 1.4.0.dev1-45+commit.dacd74b4",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/codeCopyFiller.yml",
-            "sourceHash" : "9f2cd676b4ca9a934069cd0490993781984b1b7b1bc42386904739b20309b90e"
+            "sourceHash" : "c2c39271bbce78de911edac62f42bf1981dc37a7e897a8564e4c072074482a2d"
         },
         "env" : {
             "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",

--- a/GeneralStateTests/stEWASMTests/codeCopy.json
+++ b/GeneralStateTests/stEWASMTests/codeCopy.json
@@ -2,7 +2,7 @@
     "codeCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.4.0.dev1-45+commit.dacd74b4",
+            "filledwith" : "testeth 1.4.0.dev0-68+commit.fd97ef4b",
             "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/codeCopyFiller.yml",
             "sourceHash" : "c2c39271bbce78de911edac62f42bf1981dc37a7e897a8564e4c072074482a2d"

--- a/GeneralStateTests/stEWASMTests/extCodeCopy.json
+++ b/GeneralStateTests/stEWASMTests/extCodeCopy.json
@@ -2,10 +2,10 @@
     "extCodeCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "cpp-1.3.0+commit.95f94329.Darwin.appleclang",
-            "lllcversion" : "Version: 0.4.20-develop.2018.1.2+commit.efc198d5.Darwin.appleclang",
+            "filledwith" : "testeth 1.4.0.dev1-45+commit.dacd74b4",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/extCodeCopyFiller.yml",
-            "sourceHash" : "74c724420172e84ceec661e5072297a91884e80fae5b0a8b0624a9cc8e1775b9"
+            "sourceHash" : "4f910919025311f3b8d8bad8073e5edba36635f09a135e1601fb0a237aed820d"
         },
         "env" : {
             "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
@@ -18,7 +18,7 @@
         "post" : {
             "Byzantium" : [
                 {
-                    "hash" : "0x02412470173aa36adfe4448d95843782763369f8c4167724764644f675a560e5",
+                    "hash" : "0xca3e6ef41cda6728abf473eae22514bad6a20978ce2a9b7f6e9a2f5723b87646",
                     "indexes" : {
                         "data" : 0,
                         "gas" : 0,
@@ -45,7 +45,7 @@
             },
             "0xdeadbeef00000000000000000000000000000001" : {
                 "balance" : "0x174876e800",
-                "code" : "0x0061736d01000000010f0360037f7f7f0060027f7f00600000022d0208657468657265756d08636f6465436f7079000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102066d656d6f72790200046d61696e00020a13011100410041004114100041e400410010010b0026046e616d65011f030008636f6465436f7079010c73746f7261676553746f726502046d61696e",
+                "code" : "0x0061736d01000000010401600000030201000503010001071102066d656d6f72790200046d61696e00000a05010300000b000e046e616d6501070100046d61696e",
                 "nonce" : "0x00",
                 "storage" : {
                 }

--- a/GeneralStateTests/stEWASMTests/extCodeCopy.json
+++ b/GeneralStateTests/stEWASMTests/extCodeCopy.json
@@ -2,7 +2,7 @@
     "extCodeCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.4.0.dev1-45+commit.dacd74b4",
+            "filledwith" : "testeth 1.4.0.dev0-68+commit.fd97ef4b",
             "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/extCodeCopyFiller.yml",
             "sourceHash" : "4f910919025311f3b8d8bad8073e5edba36635f09a135e1601fb0a237aed820d"

--- a/GeneralStateTests/stEWASMTests/returnDataCopy.json
+++ b/GeneralStateTests/stEWASMTests/returnDataCopy.json
@@ -2,10 +2,10 @@
     "returnDataCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.4.0.dev1-45+commit.dacd74b4",
+            "filledwith" : "testeth 1.4.0.dev0-68+commit.fd97ef4b",
             "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/returnDataCopyFiller.yml",
-            "sourceHash" : "a9a9d093481c5c8cf66855a9f14c0c2cba6bd0bc9c8ac745c68e9f16ecddd630"
+            "sourceHash" : "186f669999ce6f79108d359322f06f6d6dc80fbac0ee5a5b3027c88d76090208"
         },
         "env" : {
             "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",

--- a/GeneralStateTests/stEWASMTests/returnDataCopy.json
+++ b/GeneralStateTests/stEWASMTests/returnDataCopy.json
@@ -1,0 +1,70 @@
+{
+    "returnDataCopy" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0.dev1-45+commit.dacd74b4",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/returnDataCopyFiller.yml",
+            "sourceHash" : "a9a9d093481c5c8cf66855a9f14c0c2cba6bd0bc9c8ac745c68e9f16ecddd630"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xda59071d848b78bbe490e034359d8fc2d441a1db87a52d8fedd97030efb1502c",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x04",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000000" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000011c0560057e7f7f7f7f017f60027f7f006000017f60037f7f7f0060000002600408657468657265756d0463616c6c000008657468657265756d0c73746f7261676553746f7265000108657468657265756d1167657452657475726e4461746153697a65000208657468657265756d0e72657475726e44617461436f70790003030201040503010001071102066d656d6f72790200046d61696e00040a6e016c01097f410021004120210141c000210241e0002103418001210441a001210541c001210720014101360200200241023602002003410036020020044100360200200742a08d06200020032004410010003602002001200710011002210820054100200810032002200510010b0b1a010041000b1401000000000000000000000000000000efbeadde0045046e616d65013e05000463616c6c010c73746f7261676553746f7265021167657452657475726e4461746153697a65030e72657475726e44617461436f707904046d61696e",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x00",
+                "code" : "0x0061736d0100000001090260027f7f0060000002130108657468657265756d0672657475726e0000030201010503010001071102066d656d6f72790200046d61696e00010a15011301027f4180042100410421012000200110000b0b0b01004180040b04deadbeef0016046e616d65010f02000672657475726e01046d61696e",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x6acfc0"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x04",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xdeadbeef00000000000000000000000000000000",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/src/GeneralStateTestsFiller/stEWASMTests/codeCopyFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/codeCopyFiller.yml
@@ -16,9 +16,9 @@ codeCopy:
       balance: '100000000000'
       code: |
         (module
-          (import  "ethereum" "codeCopy"  (func $codeCopy (param i32 i32 i32)))
-          (import  "ethereum" "storageStore"  (func $storageStore (param i32 i32)))
-          (memory 1 )
+          (import "ethereum" "codeCopy" (func $codeCopy (param i32 i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
           (export "memory" (memory 0))
           (export "main" (func $main))
 
@@ -28,9 +28,7 @@ codeCopy:
           )
         )
       nonce: ''
-      storage: {
-        0: "0x00"
-      }
+      storage: {}
   expect:
     - indexes:
         data: !!int -1
@@ -50,6 +48,9 @@ codeCopy:
           balance: "99999958858"
         deadbeef00000000000000000000000000000000:
           storage: {
+            # This storage slot should contain the first ten bytes of the code contained
+            # at this address. Note that it's in little-endian order, so it's the reverse
+            # of the code contained in the filled test file.
             0: "0x0f01000000016d736100"
           }
   transaction:

--- a/src/GeneralStateTestsFiller/stEWASMTests/extCodeCopyFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/extCodeCopyFiller.yml
@@ -18,15 +18,13 @@ extCodeCopy:
       storage: {}
       code: |
         (module
-          (import "ethereum" "codeCopy" (func $codeCopy (param i32 i32 i32)))
-          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
           (memory 1)
           (export "memory" (memory 0))
           (export "main" (func $main))
 
           (func $main
-            (call $codeCopy (i32.const 0) (i32.const 0) (i32.const 20))
-            (call $storageStore (i32.const 100) (i32.const 0))
+            ;; this code is never actually called
+            (unreachable)
           )
         )
     deadbeef00000000000000000000000000000000:
@@ -41,7 +39,16 @@ extCodeCopy:
           (export "main" (func $main))
 
           (func $main
-            (call $externalCodeCopy (i32.const 0) (i32.const 200) (i32.const 0) (i32.const 10))
+            (call $externalCodeCopy
+              ;; addressOffset: the memory offset to load the address from
+              (i32.const 0)
+              ;; resultOffset: the memory offset to load the result into
+              (i32.const 200)
+              ;; codeOffset the offset within the code
+              (i32.const 0)
+              ;; length the length of code to copy
+              (i32.const 10)
+            )
             (call $storageStore (i32.const 100) (i32.const 200))
           )
         )
@@ -60,10 +67,10 @@ extCodeCopy:
         a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
           balance: "99999958297"
         deadbeef00000000000000000000000000000000:
-          # 0x0061736d01000000010f backwards
+          # 0x0061736d010000000104 backwards
           storage: {
-            0: '0x0f01000000016d736100'
-            }
+            0: '0x0401000000016d736100'
+          }
   transaction:
     data:
     - ''

--- a/src/GeneralStateTestsFiller/stEWASMTests/extCodeCopyFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/extCodeCopyFiller.yml
@@ -18,9 +18,9 @@ extCodeCopy:
       storage: {}
       code: |
         (module
-          (import  "ethereum" "codeCopy"  (func $codeCopy (param i32 i32 i32)))
-          (import  "ethereum" "storageStore"  (func $storageStore (param i32 i32)))
-          (memory 1 )
+          (import "ethereum" "codeCopy" (func $codeCopy (param i32 i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
           (export "memory" (memory 0))
           (export "main" (func $main))
 
@@ -33,10 +33,10 @@ extCodeCopy:
       balance: '100000000000'
       code: |
         (module
-          (import  "ethereum" "externalCodeCopy"  (func $externalCodeCopy (param i32 i32 i32 i32)))
-          (import  "ethereum" "storageStore"  (func $storageStore (param i32 i32)))
-          (memory 1 )
-          (data (i32.const 0)  "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (import "ethereum" "externalCodeCopy" (func $externalCodeCopy (param i32 i32 i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
           (export "memory" (memory 0))
           (export "main" (func $main))
 

--- a/src/GeneralStateTestsFiller/stEWASMTests/returnDataCopyFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/returnDataCopyFiller.yml
@@ -1,0 +1,161 @@
+# Simple test to read return data using returnDataCopy
+returnDataCopy:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0x4'
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '0'
+      nonce: ''
+      storage: {}
+      code: |
+        (module
+          (import "ethereum" "return" (func $return (param i32 i32)))
+          (memory 1)
+          ;; data to return
+          (data (i32.const 512) "\de\ad\be\ef")
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; locals
+            (local $ptrCode i32)
+            (local $codeLen i32)
+
+            ;; memory, init
+            (set_local $ptrCode (i32.const 512))
+            (set_local $codeLen (i32.const 4))
+
+            (call $return
+              (get_local $ptrCode)
+              (get_local $codeLen)
+            )
+          )
+        )
+    deadbeef00000000000000000000000000000000:
+      balance: '100000000000'
+      nonce: ''
+      storage: {}
+      code: |
+        (module
+          (import "ethereum" "call" (func $call (param i64 i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "getReturnDataSize" (func $getReturnDataSize (result i32)))
+          (import "ethereum" "returnDataCopy" (func $returnDataCopy (param i32 i32 i32)))
+          (memory 1)
+
+          ;; Location of contract to call
+          (data (i32.const 0) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; locals
+            (local $ptrCallAddr i32)
+            (local $ptrStorageKey1 i32)
+            (local $ptrStorageKey2 i32)
+            (local $ptrValue i32)
+            (local $ptrData i32)
+            (local $ptrResult i32)
+            (local $codeLen i32)
+            (local $ptrCallResult i32)
+            (local $retDataSize i32)
+
+            ;; memory layout and pointers
+            (set_local $ptrCallAddr (i32.const 0))
+            (set_local $ptrStorageKey1 (i32.const 32))
+            (set_local $ptrStorageKey2 (i32.const 64))
+            (set_local $ptrValue (i32.const 96))
+            (set_local $ptrData (i32.const 128))
+            (set_local $ptrResult (i32.const 160))
+            (set_local $ptrCallResult (i32.const 192))
+
+            ;; initialize
+            (i32.store (get_local $ptrStorageKey1) (i32.const 1))
+            (i32.store (get_local $ptrStorageKey2) (i32.const 2))
+            (i32.store (get_local $ptrValue) (i32.const 0))
+            (i32.store (get_local $ptrData) (i32.const 0))
+
+            ;; call CALL and save the result (success or failure)
+            (i32.store
+              (get_local $ptrCallResult)
+              (call $call
+                ;; gas
+                (i64.const 100000)
+                ;; addrOffset
+                (get_local $ptrCallAddr)
+                ;; valOffset
+                (get_local $ptrValue)
+                ;; data offset
+                (get_local $ptrData)
+                ;; data length
+                (i32.const 0)
+              )
+            )
+
+            ;; Store the CALL result
+            (call $storageStore
+              (get_local $ptrStorageKey1)
+              (get_local $ptrCallResult)
+            )
+
+            ;; get return data size
+            (set_local $retDataSize (call $getReturnDataSize))
+
+            ;; call returnDataCopy and save the result
+            (call $returnDataCopy
+              ;; resultOffset i32ptr the memory offset to load data into (bytes)
+              (get_local $ptrResult)
+              ;; dataOffset i32 the offset in the return data
+              (i32.const 0)
+              ;; length i32 the length of data to copy
+              (get_local $retDataSize)
+            )
+
+            ;; store the result
+            (call $storageStore
+              (get_local $ptrStorageKey2)
+              (get_local $ptrResult)
+            )
+          )
+        )
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99999953295'
+        deadbeef00000000000000000000000000000000:
+          storage: {
+            # Expect CALL to return success
+            # $ptrStorageKey1 = 1
+            1: '0',
+            # Expect returnDataCopy to return four bytes, '0xdeadbeef' backwards
+            # $ptrStorageKey2 = 2
+            2: '0xefbeadde',
+          }
+  transaction:
+    data:
+    - '0x'
+    gasLimit:
+    - '0x6acfc0'
+    gasPrice: '0x01'
+    nonce: '0x04'
+    secretKey: "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    to: 'deadbeef00000000000000000000000000000000'
+    value:
+    - '0'


### PR DESCRIPTION
Split out from https://github.com/ewasm/tests/pull/52. Not impacted by the OOB memory issue discussed in https://github.com/ewasm/tests/issues/34. Adds one new test, `returnDataCopy`.