### PR TITLE
create code which calls revert instead of returning code

### DIFF
--- a/GeneralStateTests/stEWASMTests/createCodeWithRevert.json
+++ b/GeneralStateTests/stEWASMTests/createCodeWithRevert.json
@@ -1,0 +1,70 @@
+{
+    "createCodeWithRevert" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0rc5",
+            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/createCodeWithRevertFiller.yml",
+            "sourceHash" : "c8440fc6c8140c955fad41b963b1126ce0d7f5fe7028c37e9229ff89396258a4"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x9040d666be3da78d034843eeb7b597393c98341eac2b84c4fbef717ff2e01070",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa000000000000000000000000000000000000001" : {
+                "balance" : "0x00",
+                "code" : "0x0061736d0100000001090260027f7f0060000002130108657468657265756d067265766572740000030201010503010001071102066d656d6f72790200046d61696e00010a16011401027f418004210041022101418004410210000b0b0901004180040b02beef",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x04",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000000" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000011d0560047f7f7f7f017f60027f7f0060017f017f60047f7f7f7f0060000002660408657468657265756d06637265617465000008657468657265756d0c73746f7261676553746f7265000108657468657265756d1367657445787465726e616c436f646553697a65000208657468657265756d1065787465726e616c436f6465436f70790003030201040503010001071102066d656d6f72790200046d61696e00040a6c016a01087f418002210041a001210141c0012102410021034120210441c000210541e00021064180012107200341003602002004410136020020054100360200200210022101200220004100200110032007200520002001200610003602002003200710012004200610010b0b1b010041c0010b14a000000000000000000000000000000000000001",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x6acfc0"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x04",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xdeadbeef00000000000000000000000000000000",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/src/GeneralStateTestsFiller/stEWASMTests/createCodeWithRevertFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/createCodeWithRevertFiller.yml
@@ -1,0 +1,152 @@
+# Transaction to contract which creates a contract, but instead does a revert
+---
+createCodeWithRevert:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0x4'
+      storage: {}
+    # WASM source for compiled code, below:
+    a000000000000000000000000000000000000001:
+      balance: '0'
+      nonce: ''
+      storage: {}
+      code: |
+        (module
+          (import "ethereum" "revert" (func $revert (param i32 i32)))
+          (memory 1)
+          (data (i32.const 512) "\be\ef")
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; locals
+            (local $memPointerCode i32)
+            (local $codeLen i32)
+
+            ;; memory, init
+            (set_local $memPointerCode (i32.const 512))
+            (set_local $codeLen (i32.const 2))
+
+            (call $revert
+              (i32.const 512) ;; dataOffset
+              (i32.const 2)   ;; dataLength
+            )
+          )
+        )
+    
+    deadbeef00000000000000000000000000000000:
+      balance: '100000000000'
+      nonce: ''
+      storage: {}
+      code: |
+        (module
+          (import "ethereum" "create" (func $create (param i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "getExternalCodeSize" (func $getExternalCodeSize (param i32) (result i32)))
+          (import "ethereum" "externalCodeCopy" (func $externalCodeCopy (param i32 i32 i32 i32)))
+          (memory 1)
+
+          ;; copy the code from this account
+          (data (i32.const 160) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\a0")
+
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; locals
+            (local $codeMemLoc i32)
+            (local $codeLen i32)
+            (local $address i32)
+            (local $memPointerStorageKey1 i32)
+            (local $memPointerStorageKey2 i32)
+            (local $memPointerCreateValue i32)
+            (local $memPointerCreateResult i32)
+
+            ;; Location and length of code stored in (data) section above
+            (set_local $codeMemLoc (i32.const 256))
+            (set_local $codeLen (i32.const 128))
+            (set_local $address (i32.const 160))
+
+            ;; memory layout and pointers
+            (set_local $memPointerStorageKey1 (i32.const 0))
+            (set_local $memPointerStorageKey2 (i32.const 32))
+            (set_local $memPointerCreateValue (i32.const 64))
+            (set_local $memPointerCreateResult (i32.const 96))
+
+            ;; initialize
+            (i32.store (get_local $memPointerStorageKey1) (i32.const 0))
+            (i32.store (get_local $memPointerStorageKey2) (i32.const 1))
+            ;; call create with value transfer 0
+            (i32.store (get_local $memPointerCreateValue) (i32.const 0))
+
+            ;; get external code
+            (i32.store (get_local $codeLen)
+              (call $getExternalCodeSize (get_local $address)))
+            (call $externalCodeCopy
+              (get_local $address)
+              (get_local $codeMemLoc)
+              (i32.const 0)
+              (i32.load (get_local $codeLen)))
+
+
+            ;; call CREATE and store the return success/failure value
+            (call $storageStore
+              (get_local $memPointerStorageKey1)
+              (call $create
+                ;; value offset
+                (get_local $memPointerCreateValue)
+                ;; data offset
+                (get_local $codeMemLoc)
+                ;; data length
+                (i32.load (get_local $codeLen))
+                ;; result offset (new contract address)
+                (get_local $memPointerCreateResult)
+              )
+            )
+
+            ;; store the result (new contract address)
+            (call $storageStore
+              (get_local $memPointerStorageKey2)
+              (get_local $memPointerCreateResult)
+            )
+          )
+        )
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99999922000'
+        deadbeef00000000000000000000000000000000:
+          storage: {
+            # Expect CREATE to return failure
+            # $memPointerStorageKey1 = 0
+            0: '0x01',
+            # $memPointerStorageKey2 = 1
+            1: '',
+          }
+
+  transaction:
+    data:
+    - '0x'
+    gasLimit:
+    - '0x6acfc0'
+    gasPrice: '0x01'
+    nonce: '0x04'
+    secretKey: "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    to: 'deadbeef00000000000000000000000000000000'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/createCodeWithRevertFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/createCodeWithRevertFiller.yml
@@ -56,7 +56,7 @@ createCodeWithRevert:
           (memory 1)
 
           ;; copy the code from this account
-          (data (i32.const 160) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\a0")
+          (data (i32.const 192) "\a0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01")
 
           (export "memory" (memory 0))
           (export "main" (func $main))
@@ -70,17 +70,19 @@ createCodeWithRevert:
             (local $memPointerStorageKey2 i32)
             (local $memPointerCreateValue i32)
             (local $memPointerCreateResult i32)
+            (local $memPointerCreateRetCode i32)
 
             ;; Location and length of code stored in (data) section above
             (set_local $codeMemLoc (i32.const 256))
-            (set_local $codeLen (i32.const 128))
-            (set_local $address (i32.const 160))
+            (set_local $codeLen (i32.const 160))
+            (set_local $address (i32.const 192))
 
             ;; memory layout and pointers
             (set_local $memPointerStorageKey1 (i32.const 0))
             (set_local $memPointerStorageKey2 (i32.const 32))
             (set_local $memPointerCreateValue (i32.const 64))
             (set_local $memPointerCreateResult (i32.const 96))
+            (set_local $memPointerCreateRetCode (i32.const 128))
 
             ;; initialize
             (i32.store (get_local $memPointerStorageKey1) (i32.const 0))
@@ -89,29 +91,30 @@ createCodeWithRevert:
             (i32.store (get_local $memPointerCreateValue) (i32.const 0))
 
             ;; get external code
-            (i32.store (get_local $codeLen)
+            (set_local $codeLen
               (call $getExternalCodeSize (get_local $address)))
+
             (call $externalCodeCopy
               (get_local $address)
               (get_local $codeMemLoc)
               (i32.const 0)
-              (i32.load (get_local $codeLen)))
+              (get_local $codeLen))
 
-
-            ;; call CREATE and store the return success/failure value
-            (call $storageStore
-              (get_local $memPointerStorageKey1)
+            (i32.store (get_local $memPointerCreateRetCode)
               (call $create
                 ;; value offset
                 (get_local $memPointerCreateValue)
                 ;; data offset
                 (get_local $codeMemLoc)
                 ;; data length
-                (i32.load (get_local $codeLen))
+                (get_local $codeLen)
                 ;; result offset (new contract address)
-                (get_local $memPointerCreateResult)
-              )
-            )
+                (get_local $memPointerCreateResult)))
+
+            ;; call CREATE and store the return success/failure value
+            (call $storageStore
+              (get_local $memPointerStorageKey1)
+              (get_local $memPointerCreateRetCode))
 
             ;; store the result (new contract address)
             (call $storageStore
@@ -129,12 +132,12 @@ createCodeWithRevert:
         - ALL
       result:
         a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
-          balance: '99999922000'
+          balance: '99999920588'
         deadbeef00000000000000000000000000000000:
           storage: {
-            # Expect CREATE to return failure
+            # Expect CREATE to return failure (2 = revert)
             # $memPointerStorageKey1 = 0
-            0: '0x01',
+            0: '0x0200000000000000000000000000000000000000000000000000000000000000',
             # $memPointerStorageKey2 = 1
             1: '',
           }


### PR DESCRIPTION
Hera is returning a wrong value when executing this test case, `CREATE`  is returning `0x0100000000000000000000000000000000000000000000000000000000000000` instead of 0x01 (failure)

Part of #85.