### PR TITLE
Test malformed imports - Part 1

### DIFF
--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeFourParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeFourParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallCodeFourParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeFourParamsFiller.yml",
+            "sourceHash" : "987d2942fc7ddfe629a49175714406a5eb1609846d96d929f6ba387160c3c127"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x86844941d87ce905d7e877f7e04763ef24b87747c384ba6a037f32d1428666df",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001100360027f7f0060047e7f7f7f00600000022d0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0863616c6c436f64650001030201020503010001071102046d61696e0002066d656d6f727902000a3d013b01057f418001210441e000210341c00021024120210141002100200141013602002003410a36020042c09a0c20022003200410012000200110000b0b24020041c0000b1401000000000000000000000000000000efbeadde004180010b03abcdef",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002190108657468657265756d0c73746f7261676553746f72650000030201010503010001071102046d61696e0001066d656d6f727902000a1c011a01027f410021004120210120004101360200200141023602000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeOneParam.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallCodeOneParam" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeOneParamFiller.yml",
+            "sourceHash" : "23e0e6c9cc81193508bac0ff0383509501cc41b4a88827db2fbd6bd8a6e90f64"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x734c6bbed700876e4217095fe36f6d1d338811747957d1b9c4287d52e1d9e9d6",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360027f7f0060017e00600000022d0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0863616c6c436f64650001030201020503010001071102046d61696e0002066d656d6f727902000a21011f01027f41202101410021002001410136020042c09a0c10012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeThreeParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallCodeThreeParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeThreeParamsFiller.yml",
+            "sourceHash" : "5838d5aecaeeadbc540c2301f8d8761621b857d3e2a501e511a1b917a91c7f64"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x66441ed0e73fa3a28cf5dabe497c674bfc95f23375bfb9aa8da51dc4a58bfe28",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010f0360027f7f0060037e7f7f00600000022d0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0863616c6c436f64650001030201020503010001071102046d61696e0002066d656d6f727902000a36013401047f41e000210341c00021024120210141002100200141013602002003410a36020042c09a0c2002200310012000200110000b0b1b010041c0000b1401000000000000000000000000000000efbeadde",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002190108657468657265756d0c73746f7261676553746f72650000030201010503010001071102046d61696e0001066d656d6f727902000a1c011a01027f410021004120210120004101360200200141023602000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeTwoParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallCodeTwoParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeTwoParamsFiller.yml",
+            "sourceHash" : "b979c0cdd2c29316743391975e0ee074ef5f3de4ae37574570331c39da996646"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x14f4c76694362fb8d59c23f5bd48360d5b3e1f5814154bc03d5489be189174f0",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010e0360027f7f0060027e7f00600000022d0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0863616c6c436f64650001030201020503010001071102046d61696e0002066d656d6f727902000a28012601037f41c000210241202101410021002001410136020042c09a0c200210012000200110000b0b1b010041c0000b1401000000000000000000000000000000efbeadde",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002190108657468657265756d0c73746f7261676553746f72650000030201010503010001071102046d61696e0001066d656d6f727902000a1c011a01027f410021004120210120004101360200200141023602000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeZeroParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallCodeZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeZeroParamsFiller.yml",
+            "sourceHash" : "fb93133d56ab25daa95545592f3f95750465cf6c474dd66db93a30d940702ba3"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x2a27680b1a7c32e6cab226b15a0194cd26d191de71bf3904e30b85c45cfd2c23",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f00600000022d0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0863616c6c436f64650001030201010503010001071102046d61696e0002066d656d6f727902000a1d011b01027f41202101410021002001410136020010012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyOneParam.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallDataCopyOneParam" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyOneParamFiller.yml",
+            "sourceHash" : "ff29e5b4fb4f420e5c075d31ddcfd34a1363b99393c5dd3a19c205eea7e13e55"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x592464a826940795ed0b15cda716f1e618b547eedfa6eac1d736eeab43ebd32e",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360027f7f0060017f0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c63616c6c44617461436f70790001030201020503010001071102046d61696e0002066d656d6f727902000a24012201037f41c0002102412021014100210020014101360200200210012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyTwoParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallDataCopyTwoParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyTwoParamsFiller.yml",
+            "sourceHash" : "50cc970bb415f3f9e8ebc25be556b2b5388299db6b8fb02ce4d997a89d1931bd"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x1c0db4bef123ad126c2b7e1dbc731613afd27be192fe2b6cbee7fcb4b1755d25",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c63616c6c44617461436f70790000030201010503010001071102046d61696e0002066d656d6f727902000a35013301047f41e000210341c0002102412021014100210020014101360200200341003602002002200328020010012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyZeroParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallDataCopyZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyZeroParamsFiller.yml",
+            "sourceHash" : "5803c1fbd4fb30692aefff7abfd518a85f1554545ec8e7abe70e29a32fba9768"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x18843d57aa0ce7a513f4eb1ac2e825d6eda65f801416df02978ca8e6a83bc2f6",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c63616c6c44617461436f70790001030201010503010001071102046d61696e0002066d656d6f727902000a1d011b01027f41202101410021002001410136020010012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataSizeOneParamNoReturn.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataSizeOneParamNoReturn.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallDataSizeOneParamNoReturn" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataSizeOneParamNoReturnFiller.yml",
+            "sourceHash" : "bef0e55bbac9a75b7d9024f8a02dd4eedee837927a286360bf8db3b537b80216"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x772929bbdea9e61ed609c025e0deced6f7ade62253dd5e022daac7c41e019aab",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360027f7f0060017f0060000002340208657468657265756d0c73746f7261676553746f7265000008657468657265756d0f67657443616c6c4461746153697a650001030201020503010001071102046d61696e0002066d656d6f727902000a24012201037f41c0002102412021014100210020014101360200200210012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataSizeOneParamWithReturn.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataSizeOneParamWithReturn.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallDataSizeOneParamWithReturn" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataSizeOneParamWithReturnFiller.yml",
+            "sourceHash" : "1b6a07c83522cb3e02ce59433a616042fb9bc727dab0603fb1f1a802766e7eaf"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xd7312a1a79b0f76f842977cba6d95738a388c23795942f4acd4eff69cce0dd73",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010e0360027f7f0060017f017f60000002340208657468657265756d0c73746f7261676553746f7265000008657468657265756d0f67657443616c6c4461746153697a650001030201020503010001071102046d61696e0002066d656d6f727902000a29012701037f41c00021024120210141002100200141013602002002200210013602002000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateFiveParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateFiveParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallDelegateFiveParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateFiveParamsFiller.yml",
+            "sourceHash" : "eafc6895ce1a9f870a06a2b6b6ef00c2e736e393c73fec55beeb59e1efd22e62"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x39664dc6a8510f200203dec8e2252fb37abe2652089f8ff94fe4288063003e25",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001120360027f7f0060057e7f7f7f7f017f60000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c63616c6c44656c65676174650001030201020503010001071102046d61696e0002066d656d6f727902000a46014401077f41a0012106418001210541e000210341c000210241202101410021004103210420014101360200200642c09a0c200220032004200510013602002000200110000b0b24020041c0000b1401000000000000000000000000000000efbeadde0041e0000b03abcdef",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateOneParam.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallDelegateOneParam" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateOneParamFiller.yml",
+            "sourceHash" : "cf0a0db7d8994d35ab6464bceaca003ba1676a5d683e241504f1177b35311861"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x64f238ef6964cc5718c22fcebd5a79f32e311222a9c2f93ca02ac5f809340735",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360027f7f0060017e0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c63616c6c44656c65676174650001030201020503010001071102046d61696e0002066d656d6f727902000a21011f01027f41202101410021002001410136020042c09a0c10012000200110000b0b0100",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateThreeParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallDelegateThreeParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateThreeParamsFiller.yml",
+            "sourceHash" : "bb315bf100bbfbd506846322e1dc5ce375ed3549233423303c0ea0782cacf0ec"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x0cd6526828a256508c952506d7f987b12ce42d9b79b6c393b635400755ba9f27",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010f0360027f7f0060037e7f7f0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c63616c6c44656c65676174650001030201020503010001071102046d61696e0002066d656d6f727902000a2f012d01047f41e000210341c000210241202101410021002001410136020042c09a0c2002200310012000200110000b0b24020041c0000b1401000000000000000000000000000000efbeadde0041e0000b03abcdef",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateTwoParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallDelegateTwoParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateTwoParamsFiller.yml",
+            "sourceHash" : "455984e231a976c16b4abde3953c231d0cd26a5924f142f218efea80843cbe2e"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x8f3904e25f9c50daf4143885bd3f19837ff2b8c57f8c41e6e42f62da18d87bf1",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010e0360027f7f0060027e7f0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c63616c6c44656c65676174650001030201020503010001071102046d61696e0002066d656d6f727902000a28012601037f41c000210241202101410021002001410136020042c09a0c200210012000200110000b0b1b010041c0000b1401000000000000000000000000000000efbeadde",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateZeroParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallDelegateZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateZeroParamsFiller.yml",
+            "sourceHash" : "442ac7b45aa2a7c6e7a1a821804f46f384763edc23c14627063f9a0bef715029"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xe4104c6c147b91ed87f3902c430168c1ca2ef7031a3ed3e418ecd02ce5d8f688",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c63616c6c44656c65676174650001030201010503010001071102046d61696e0002066d656d6f727902000a1d011b01027f41202101410021002001410136020010012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallFourParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallFourParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallFourParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallFourParamsFiller.yml",
+            "sourceHash" : "1a5998218261baca2938c7aec43a37c01d9f784e7a8837d0d77c7f9a198a85b5"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xd43c50ee1eaafa55f7516470a59b42b0679fc3b72940fb75d3e989f77dff9a26",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001100360027f7f0060047e7f7f7f0060000002290208657468657265756d0c73746f7261676553746f7265000008657468657265756d0463616c6c0001030201020503010001071102046d61696e0002066d656d6f727902000a3d013b01057f418001210441e000210341c00021024120210141002100200141013602002003410a36020042c09a0c20022003200410012000200110000b0b25020041c0000b1401000000000000000000000000000000efbeadde004180010b04deadbeef",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002190108657468657265756d0c73746f7261676553746f72650000030201010503010001071102046d61696e0001066d656d6f727902000a22012001027f410021004120210120004100360200200141013602002000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallOneParam.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallOneParam" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallOneParamFiller.yml",
+            "sourceHash" : "7bc0c0b2d7c8fd8517bb217b982324e70b89b876d7319ee6d642061894e72858"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x68c79d9cf13b1bb5d8e298236951cd78431408d4de91a681d2938b40df740fbe",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360027f7f0060017e0060000002290208657468657265756d0c73746f7261676553746f7265000008657468657265756d0463616c6c0001030201020503010001071102046d61696e0002066d656d6f727902000a21011f01027f41202101410021002001410136020042c09a0c10012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticFiveParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticFiveParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallStaticFiveParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticFiveParamsFiller.yml",
+            "sourceHash" : "d2c30e8222a002abf179ed1067084d91ea2da51d53e755c809cc38747ceb5e7f"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x36a15ffebb968996ebc9a6ac225b181c4919459d3fddb64c4e01d3e413233af4",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001120360027f7f0060057e7f7f7f7f017f600000022f0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0a63616c6c5374617469630001030201020503010001071102046d61696e0002066d656d6f727902000a46014401077f41a0012106418001210541e000210341c000210241202101410021004103210420014101360200200642c09a0c200220032004200510013602002000200110000b0b24020041c0000b1401000000000000000000000000000000efbeadde0041e0000b03abcdef",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticOneParam.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallStaticOneParam" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticOneParamFiller.yml",
+            "sourceHash" : "a1ec9377778ee40d98957cb28e4c8692a6ae6e28425d4f7bf0968fb9f77b2f16"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xde5d31be13888219976e64e3bdd341e23b297dfa9043001d215a26e1846fd8c6",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360027f7f0060017e00600000022f0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0a63616c6c5374617469630001030201020503010001071102046d61696e0002066d656d6f727902000a21011f01027f41202101410021002001410136020042c09a0c10012000200110000b0b0100",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticThreeParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallStaticThreeParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticThreeParamsFiller.yml",
+            "sourceHash" : "85a5a663660bf30fc9a75d1dec28d6d4266d677a0f7f6ebf62d4a17957cd59b1"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x08fc5950b97349392fb3e312e1e8e1a9068b5c04ac0f11b5859c993d956fc115",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010f0360027f7f0060037e7f7f00600000022f0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0a63616c6c5374617469630001030201020503010001071102046d61696e0002066d656d6f727902000a2f012d01047f41e000210341c000210241202101410021002001410136020042c09a0c2002200310012000200110000b0b24020041c0000b1401000000000000000000000000000000efbeadde0041e0000b03abcdef",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticTwoParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallStaticTwoParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticTwoParamsFiller.yml",
+            "sourceHash" : "264890ef3114d6fb207a98e79318b1290d4c2962d39cd4357f3b3b39b72dadd3"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x5c0dc85be8f7a4463f9bd2d6a760a1b02364cc5ae48ea444bd6666a785b4f58c",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010e0360027f7f0060027e7f00600000022f0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0a63616c6c5374617469630001030201020503010001071102046d61696e0002066d656d6f727902000a28012601037f41c000210241202101410021002001410136020042c09a0c200210012000200110000b0b1b010041c0000b1401000000000000000000000000000000efbeadde",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticZeroParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallStaticZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticZeroParamsFiller.yml",
+            "sourceHash" : "b59d3ad4e77d5e44bc3d21a28361d3a0e63c1de0eba26a919c30cf1d2d8b6c29"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x5c7140f2b5e132490c6f57f16e475602c560a1709da56c10b2421537880300c5",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f00600000022f0208657468657265756d0c73746f7261676553746f7265000008657468657265756d0a63616c6c5374617469630001030201010503010001071102046d61696e0002066d656d6f727902000a1d011b01027f41202101410021002001410136020010012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallThreeParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallThreeParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallThreeParamsFiller.yml",
+            "sourceHash" : "302354da985677c99a6367ab9114e39c6a3fb031a0dceeed1ed5e8ee4bde4308"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x789ba8ca763fb9ea9c92a03e31b82521e77ef0e9f2e8a8c862f06c04b6c0cebe",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010f0360027f7f0060037e7f7f0060000002290208657468657265756d0c73746f7261676553746f7265000008657468657265756d0463616c6c0001030201020503010001071102046d61696e0002066d656d6f727902000a36013401047f41e000210341c00021024120210141002100200141013602002003410a36020042c09a0c2002200310012000200110000b0b1b010041c0000b1401000000000000000000000000000000efbeadde",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002190108657468657265756d0c73746f7261676553746f72650000030201010503010001071102046d61696e0001066d656d6f727902000a22012001027f410021004120210120004100360200200141013602002000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallTwoParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportCallTwoParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallTwoParamsFiller.yml",
+            "sourceHash" : "cc5818fd2177a1a256f9281cee1a393e0e0bc0011be838a61be5f1512d596849"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xbfc58877f209d126d30d957144eae694e3fac349ef615773381bf4e0db53aef5",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010e0360027f7f0060027e7f0060000002290208657468657265756d0c73746f7261676553746f7265000008657468657265756d0463616c6c0001030201020503010001071102046d61696e0002066d656d6f727902000a28012601037f41c000210241202101410021002001410136020042c09a0c200210012000200110000b0b1b010041c0000b1401000000000000000000000000000000efbeadde",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002190108657468657265756d0c73746f7261676553746f72650000030201010503010001071102046d61696e0001066d656d6f727902000a22012001027f410021004120210120004100360200200141013602002000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportCallZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallZeroParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportCallZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallZeroParamsFiller.yml",
+            "sourceHash" : "fbc9d327dcd05e4087dda48045d56156f1a432e77a93dfe2e5325312c20ce430"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x2cae759be1c9bad484e558af3d2375822c2d2ae73db25b0f702392188c8aaae1",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002290208657468657265756d0c73746f7261676553746f7265000008657468657265756d0463616c6c0001030201010503010001071102046d61696e0002066d656d6f727902000a1d011b01027f41202101410021002001410136020010012000200110000b",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeFourParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeFourParamsFiller.yml
@@ -1,0 +1,96 @@
+# malformed import test for callCode, using four params
+---
+malformedImportCallCodeFourParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callCode"   (func $callCode (param i64 i32 i32 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (data (i32.const 128) "\ab\cd\ef")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addrOffset i32)
+            (local $valueOffset i32)
+            (local $dataOffset i32)
+
+            (set_local $dataOffset  (i32.const 128))
+            (set_local $valueOffset (i32.const 96))
+            (set_local $addrOffset  (i32.const 64))
+            (set_local $valOffset   (i32.const 32))
+            (set_local $keyOffset   (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1))    ;; storage value
+            (i32.store (get_local $valueOffset) (i32.const 10)) ;; value to send in callCode
+
+            (call $callCode (i64.const 200000) (get_local $addrOffset) (get_local $valueOffset) (get_local $dataOffset))
+
+            ;; the following function call should not be executed since callCode fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            (i32.store (get_local $keyOffset) (i32.const 1))   ;; key 0
+            (i32.store (get_lcoal $valOffset) (i32.const 2)))) ;; value 2
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0', # should not store anything here since callCode fails prior to storageStore execution
+            1: '0x0'  # this storage slot is not changed since callCode is not successful
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeOneParamFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeOneParamFiller.yml
@@ -1,0 +1,67 @@
+# malformed import test for callCode, using one param
+---
+malformedImportCallCodeOneParam:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callCode"   (func $callCode (param i64)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+
+            ;;                        gas limit
+            (call $callCode (i64.const 200000))
+
+            ;; the following function call should not be executed since callCode fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callCode fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeThreeParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeThreeParamsFiller.yml
@@ -1,0 +1,93 @@
+# malformed import test for callCode, using three params
+---
+malformedImportCallCodeThreeParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callCode"   (func $callCode (param i64 i32 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addrOffset i32)
+            (local $valueOffset i32)
+
+            (set_local $valueOffset (i32.const 96))
+            (set_local $addrOffset  (i32.const 64))
+            (set_local $valOffset   (i32.const 32))
+            (set_local $keyOffset   (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1))    ;; storage value
+            (i32.store (get_local $valueOffset) (i32.const 10)) ;; value to send in callCode
+
+            (call $callCode (i64.const 200000) (get_local $addrOffset) (get_local $valueOffset))
+
+            ;; the following function call should not be executed since callCode fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            (i32.store (get_local $keyOffset) (i32.const 1))   ;; key 0
+            (i32.store (get_lcoal $valOffset) (i32.const 2)))) ;; value 2
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0', # should not store anything here since callCode fails prior to storageStore execution
+            1: '0x0'  # this storage slot is not changed since callCode is not successful
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeTwoParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeTwoParamsFiller.yml
@@ -1,0 +1,90 @@
+# malformed import test for callCode, using two params
+---
+malformedImportCallCodeTwoParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callCode"   (func $callCode (param i64 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addrOffset i32)
+
+            (set_local $addrOffset (i32.const 64))
+            (set_local $valOffset  (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+
+            (call $callCode (i64.const 200000) (get_local $addrOffset))
+
+            ;; the following function call should not be executed since callCode fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            (i32.store (get_local $keyOffset) (i32.const 1))   ;; key 0
+            (i32.store (get_lcoal $valOffset) (i32.const 2)))) ;; value 2
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0', # should not store anything here since callCode fails prior to storageStore execution
+            1: '0x0'  # this storage slot is not changed since callCode is not successful
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeZeroParamsFiller.yml
@@ -1,0 +1,66 @@
+# malformed import test for callCode, using zero params
+---
+malformedImportCallCodeZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callCode"   (func $callCode))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callCode)
+
+            ;; the following function call should not be executed since callCode fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callCode fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyOneParamFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyOneParamFiller.yml
@@ -1,0 +1,70 @@
+# malformed import test for callDataCopy, using one parameter
+---
+malformedImportCallDataCopyOneParam:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callDataCopy" (func $callDataCopy (param i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $resultOffset i32)
+
+            (set_local $resultOffset (i32.const 64))
+            (set_local $valOffset    (i32.const 32))
+            (set_local $keyOffset    (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callDataCopy (get_local $resultOffset))
+
+            ;; the following function call should not be executed since callDataCopy fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00' # should not store anything here since callDataCopy fails prior to storageStore execution
+          }
+
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyTwoParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyTwoParamsFiller.yml
@@ -1,0 +1,73 @@
+# malformed import test for callDataCopy, using two parameters
+---
+malformedImportCallDataCopyTwoParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callDataCopy" (func $callDataCopy (param i32 i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $resultOffset i32)
+            (local $dataOffset i32)
+
+            (set_local $dataOffset   (i32.const 96))
+            (set_local $resultOffset (i32.const 64))
+            (set_local $valOffset    (i32.const 32))
+            (set_local $keyOffset    (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            (i32.store (get_local $dataOffset) (i32.const 0)) ;; dataOffset = 0
+            
+            (call $callDataCopy (get_local $resultOffset) (i32.load (get_local $dataOffset)))
+
+            ;; the following function call should not be executed since callDataCopy fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00' # should not store anything here since callDataCopy fails prior to storageStore execution
+          }
+
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyZeroParamsFiller.yml
@@ -1,0 +1,68 @@
+# malformed import test for callDataCopy, using zero parameters
+---
+malformedImportCallDataCopyZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callDataCopy" (func $callDataCopy))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callDataCopy)
+
+            ;; the following function call should not be executed since callDataCopy fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00' # should not store anything here since callDataCopy fails prior to storageStore execution
+          }
+
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataSizeOneParamNoReturnFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataSizeOneParamNoReturnFiller.yml
@@ -1,0 +1,70 @@
+# malformed import test for callDataSize, using one parameter and expecting no return
+---
+malformedImportCallDataSizeOneParamNoReturn:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "getCallDataSize" (func $getCallDataSize (param i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $returnOffset i32)
+
+            (set_local $returnOffset (i32.const 64))
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $getCallDataSize (get_local $returnOffset))
+
+            ;; the following function call should not be executed since getCallDataSize fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00' # should not store anything here since callDataSize fails prior to storageStore execution
+          }
+
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataSizeOneParamWithReturnFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataSizeOneParamWithReturnFiller.yml
@@ -1,0 +1,71 @@
+# malformed import test for callDataSize, using one parameter and expecting return code
+---
+malformedImportCallDataSizeOneParamWithReturn:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "getCallDataSize" (func $getCallDataSize (param i32) (result i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $returnOffset i32)
+
+            (set_local $returnOffset (i32.const 64))
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+
+            (i32.store (get_local $returnOffset)
+              (call $getCallDataSize (get_local $returnOffset)))
+
+            ;; the following function call should not be executed since getCallDataSize fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00' # should not store anything here since callDataSize fails prior to storageStore execution
+          }
+
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateFiveParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateFiveParamsFiller.yml
@@ -1,0 +1,87 @@
+# malformed import test for callDelegate, using five params
+---
+malformedImportCallDelegateFiveParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callDelegate"   (func $callDelegate (param i64 i32 i32 i32 i32) (result i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (data (i32.const 96) "\ab\cd\ef")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addressOffset i32)
+            (local $dataOffset i32)
+            (local $dataLength i32)
+            (local $invalidParam i32)
+            (local $returnOffset i32)
+
+            (set_local $returnOffset (i32.const 160))
+            (set_local $invalidParam (i32.const 128))
+            (set_local $dataOffset (i32.const 96))
+            (set_local $addressOffset (i32.const 64))
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (set_local $dataLength (i32.const 3))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+
+            (i32.store (get_local $returnOffset)
+              (call $callDelegate (i64.const 200000) (get_local $addressOffset) (get_local $dataOffset) (get_local $dataLength) (get_local $invalidParam)))
+
+            ;; the following function call should not be executed since callDelegate fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module)
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callDelegate fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateOneParamFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateOneParamFiller.yml
@@ -1,0 +1,67 @@
+# malformed import test for callDelegate, using one param
+---
+malformedImportCallDelegateOneParam:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callDelegate"   (func $callDelegate (param i64)))
+          (memory 1)
+          (data (i32.const 64) "")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callDelegate (i64.const 200000))
+
+            ;; the following function call should not be executed since callDelegate fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callDelegate fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateThreeParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateThreeParamsFiller.yml
@@ -1,0 +1,79 @@
+# malformed import test for callDelegate, using three params
+---
+malformedImportCallDelegateThreeParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callDelegate"   (func $callDelegate (param i64 i32 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (data (i32.const 96) "\ab\cd\ef")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addressOffset i32)
+            (local $dataOffset i32)
+
+            (set_local $dataOffset (i32.const 96))
+            (set_local $addressOffset (i32.const 64))
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callDelegate (i64.const 200000) (get_local $addressOffset) (get_local $dataOffset))
+
+            ;; the following function call should not be executed since callDelegate fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module)
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callDelegate fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateTwoParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateTwoParamsFiller.yml
@@ -1,0 +1,76 @@
+# malformed import test for callDelegate, using two params
+---
+malformedImportCallDelegateTwoParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callDelegate"   (func $callDelegate (param i64 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addressOffset i32)
+            
+            (set_local $addressOffset (i32.const 64))
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callDelegate (i64.const 200000) (get_local $addressOffset))
+
+            ;; the following function call should not be executed since callDelegate fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module)
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callDelegate fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateZeroParamsFiller.yml
@@ -1,0 +1,66 @@
+# malformed import test for callDelegate, using zero params
+---
+malformedImportCallDelegateZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callDelegate"   (func $callDelegate))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callDelegate)
+
+            ;; the following function call should not be executed since callDelegate fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callDelegate fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallFourParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallFourParamsFiller.yml
@@ -1,0 +1,101 @@
+# malformed import test for call, using four parameters
+---
+malformedImportCallFourParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "call"   (func $call (param i64 i32 i32 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (data (i32.const 128) "\de\ad\be\ef")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addrOffset i32)
+            (local $sendVal i32)
+            (local $dataOffset i32)
+
+            (set_local $dataOffset (i32.const 128))
+            (set_local $sendVal    (i32.const 96))
+            (set_local $addrOffset (i32.const 64))
+            (set_local $valOffset  (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value (to store in storage position 0)
+            (i32.store (get_local $sendVal)   (i32.const 10)) ;; value to be sent to the called contract
+            
+            (call $call (i64.const 200000) (get_local $addrOffset) (get_local $sendVal) (get_local $dataOffset))
+
+            ;; the following function call should not be executed since call fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            (i32.store (get_local $keyOffset) (i32.const 0)) ;; key 0
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; val 1
+
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: '0'
+      storage: {}      
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since call fails prior to storageStore execution
+          }
+        deadbeef00000000000000000000000000000001:
+          storage: {
+            0: '0x0' # nothing should be stored since call is "called" incorrectly
+            }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallOneParamFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallOneParamFiller.yml
@@ -1,0 +1,66 @@
+# malformed import test for call, using one parameter
+---
+malformedImportCallOneParam:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "call"   (func $call (param i64)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $call (i64.const 200000))
+
+            ;; the following function call should not be executed since call fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since "call" fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticFiveParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticFiveParamsFiller.yml
@@ -1,0 +1,87 @@
+# malformed import test for callStatic, using five params
+---
+malformedImportCallStaticFiveParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callStatic"   (func $callStatic (param i64 i32 i32 i32 i32) (result i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (data (i32.const 96) "\ab\cd\ef")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addressOffset i32)
+            (local $dataOffset i32)
+            (local $dataLength i32)
+            (local $invalidParam i32)
+            (local $returnOffset i32)
+
+            (set_local $returnOffset (i32.const 160))
+            (set_local $invalidParam (i32.const 128))
+            (set_local $dataOffset (i32.const 96))
+            (set_local $addressOffset (i32.const 64))
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (set_local $dataLength (i32.const 3))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+
+            (i32.store (get_local $returnOffset)
+              (call $callStatic (i64.const 200000) (get_local $addressOffset) (get_local $dataOffset) (get_local $dataLength) (get_local $invalidParam)))
+
+            ;; the following function call should not be executed since callStatic fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module)
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callStatic fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticOneParamFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticOneParamFiller.yml
@@ -1,0 +1,67 @@
+# malformed import test for callStatic, using one param
+---
+malformedImportCallStaticOneParam:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callStatic"   (func $callStatic (param i64)))
+          (memory 1)
+          (data (i32.const 64) "")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callStatic (i64.const 200000))
+
+            ;; the following function call should not be executed since callStatic fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callStatic fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticThreeParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticThreeParamsFiller.yml
@@ -1,0 +1,79 @@
+# malformed import test for callStatic, using three params
+---
+malformedImportCallStaticThreeParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callStatic"   (func $callStatic (param i64 i32 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (data (i32.const 96) "\ab\cd\ef")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addressOffset i32)
+            (local $dataOffset i32)
+
+            (set_local $dataOffset (i32.const 96))
+            (set_local $addressOffset (i32.const 64))
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callStatic (i64.const 200000) (get_local $addressOffset) (get_local $dataOffset))
+
+            ;; the following function call should not be executed since callStatic fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module)
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callStatic fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticTwoParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticTwoParamsFiller.yml
@@ -1,0 +1,76 @@
+# malformed import test for callStatic, using two params
+---
+malformedImportCallStaticTwoParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callStatic"   (func $callStatic (param i64 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addressOffset i32)
+            
+            (set_local $addressOffset (i32.const 64))
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callStatic (i64.const 200000) (get_local $addressOffset))
+
+            ;; the following function call should not be executed since callStatic fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module)
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callStatic fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticZeroParamsFiller.yml
@@ -1,0 +1,66 @@
+# malformed import test for callStatic, using zero params
+---
+malformedImportCallStaticZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "callStatic"   (func $callStatic))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $callStatic)
+
+            ;; the following function call should not be executed since callStatic fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since callStatic fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallThreeParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallThreeParamsFiller.yml
@@ -1,0 +1,98 @@
+# malformed import test for call, using three parameters
+---
+malformedImportCallThreeParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "call"   (func $call (param i64 i32 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addrOffset i32)
+            (local $sendVal i32)
+
+            (set_local $sendVal    (i32.const 96))
+            (set_local $addrOffset (i32.const 64))
+            (set_local $valOffset  (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value (to store in storage position 0)
+            (i32.store (get_local $sendVal)   (i32.const 10)) ;; value to be sent to the called contract
+            
+            (call $call (i64.const 200000) (get_local $addrOffset) (get_local $sendVal))
+
+            ;; the following function call should not be executed since call fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            (i32.store (get_local $keyOffset) (i32.const 0)) ;; key 0
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; val 1
+
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: '0'
+      storage: {}      
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since "call" fails prior to storageStore execution
+          }
+        deadbeef00000000000000000000000000000001:
+          storage: {
+            0: '0x0' # nothing should be stored since call is "called" incorrectly
+            }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallTwoParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallTwoParamsFiller.yml
@@ -1,0 +1,95 @@
+# malformed import test for call, using two parameters
+---
+malformedImportCallTwoParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "call"   (func $call (param i64 i32)))
+          (memory 1)
+          (data (i32.const 64) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\ef\be\ad\de")
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addrOffset i32)
+
+            (set_local $addrOffset (i32.const 64))
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $call (i64.const 200000) (get_local $addrOffset))
+
+            ;; the following function call should not be executed since call fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            (i32.store (get_local $keyOffset) (i32.const 0)) ;; key 0
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; val 1
+
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: '0'
+      storage: {}      
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00' # should not store anything here since "call" fails prior to storageStore execution
+          }
+        deadbeef00000000000000000000000000000001:
+          storage: {
+            0: '0x0' # nothing should be stored since call is "called" incorrectly
+            }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallZeroParamsFiller.yml
@@ -1,0 +1,66 @@
+# malformed import test for call, using zero params
+---
+malformedImportCallZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "call"   (func $call))
+          (memory 1)
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (set_local $valOffset (i32.const 32))
+            (set_local $keyOffset  (i32.const 0))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value
+            
+            (call $call)
+
+            ;; the following function call should not be executed since call fails
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset)))) ;; try to store value 1 in key 0
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        # initialGas     txGas (0x5000001)
+        # 100000000000 - 83886081           = 99916113919
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since "call" fails prior to storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'


### PR DESCRIPTION
This PR contains the following test cases for malformed imports:

- [X] malformedImportCallCodeFourParams
- [X] malformedImportCallCodeOneParam
- [X] malformedImportCallCodeThreeParams
- [X] malformedImportCallCodeTwoParams
- [X] malformedImportCallCodeZeroParams
- [X] malformedImportCallDataCopyOneParam
- [X] malformedImportCallDataCopyTwoParams
- [X] malformedImportCallDataCopyZeroParams
- [X] malformedImportCallDataSizeOneParamNoReturn
- [X] malformedImportCallDataSizeOneParamWithReturn
- [X] malformedImportCallDelegateFiveParams
- [X] malformedImportCallDelegateOneParam
- [X] malformedImportCallDelegateThreeParams
- [X] malformedImportCallDelegateTwoParams
- [X] malformedImportCallDelegateZeroParams
- [X] malformedImportCallFourParams
- [X] malformedImportCallOneParam
- [X] malformedImportCallStaticFiveParams
- [X] malformedImportCallStaticOneParam
- [X] malformedImportCallStaticThreeParams
- [X] malformedImportCallStaticTwoParams
- [X] malformedImportCallStaticZeroParams
- [X] malformedImportCallThreeParams
- [X] malformedImportCallTwoParams
- [X] malformedImportCallZeroParams