### PR TITLE
Test malformed imports - Part 5

### DIFF
--- a/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyFourParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyFourParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportReturnDataCopyFourParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyFourParamsFiller.yml",
+            "sourceHash" : "2f25a5b949df8f2e4a2956f66ee5c82d759ab55288c260ef100fb8b95c9681b4"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xfc73c3c8d18588c8bf892daa4ee5ec2508b3fd3ef4fda2dd8d9095b7da7ae15f",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001100360047f7f7f7f0060027f7f0060000002330208657468657265756d0e72657475726e44617461436f7079000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102046d61696e0002066d656d6f727902000a30012e01067f410021004120210141c000210241e0002103410a2104410a2105200220032004200510002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x0a"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyOneParam.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportReturnDataCopyOneParam" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyOneParamFiller.yml",
+            "sourceHash" : "730f8a19f9220ce7ec6afe76744d7978d023e92450c67aa8abaa443e5692b258"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xd6e9f39cd16711d93797bc9ca06a520b4252438cb0c9961be47da6fbbb52236a",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360017f0060027f7f0060000002330208657468657265756d0e72657475726e44617461436f7079000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102046d61696e0002066d656d6f727902000a1d011b01037f410021004120210141c0002102200210002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x0a"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyTwoParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportReturnDataCopyTwoParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyTwoParamsFiller.yml",
+            "sourceHash" : "fb849c5afda13c749b6e0b18b2a81673fc8cc8b9d2b745d4a4678e343817129c"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x94891f3cc07820ad31fdabbbf414bb2819965876bfb635e9dd24b151cca4a530",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002330208657468657265756d0e72657475726e44617461436f7079000008657468657265756d0c73746f7261676553746f72650000030201010503010001071102046d61696e0002066d656d6f727902000a24012201047f410021004120210141c000210241e00021032002200310002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x0a"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyZeroParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportReturnDataCopyZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyZeroParamsFiller.yml",
+            "sourceHash" : "9a7d9c96f3ad44358388801e0a5e76c84f0ef79eed5d39931883deb30d3bed84"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x8ae7e0701f70649c6bf92874c056647478d8d7446bc5ef48d28f63a3846dcbdf",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260000060027f7f0002330208657468657265756d0e72657475726e44617461436f7079000008657468657265756d0c73746f7261676553746f72650001030201000503010001071102046d61696e0002066d656d6f727902000a16011401027f410021004120210110002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x0a"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportRevertOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportRevertOneParam.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportRevertOneParam" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertOneParamFiller.yml",
+            "sourceHash" : "7bc3da2038353e8ea6f8e88956b4bbd5d00b7b8a86afb164024947859b0cbd77"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x60fddf46aa6984296cd39cbba6f1f2ca52537054421868ac981101bd3a062ef3",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360017f0060027f7f00600000022b0208657468657265756d06726576657274000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102046d61696e0002066d656d6f727902000a1d011b01037f410021004120210141c0002102200210002000200110010b0b54030041c0000b03abcdef0041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x0a"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportRevertThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportRevertThreeParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportRevertThreeParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertThreeParamsFiller.yml",
+            "sourceHash" : "0ebf933b03820eb172e0a810ba78d86288eb384e7738498caec5d425a9c2e116"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xd8dce5fbbe6041d7d5ce7df6609d15f583e15c785d2676ce5666d10336134e38",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010f0360037f7f7f0060027f7f00600000022b0208657468657265756d06726576657274000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102046d61696e0002066d656d6f727902000a29012701057f410021004120210141c000210241032103410a210420022003200410002000200110010b0b54030041c0000b03abcdef0041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x0a"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportRevertZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportRevertZeroParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportRevertZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertZeroParamsFiller.yml",
+            "sourceHash" : "dbd8b3527ee2b79c0f83537a16831308f4f8fe7fb0cecc1e391598f475384f53"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xd2c6e6901eba8451b77e970cd2aa600ac75e7598abe07d0bef3771b957456633",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260000060027f7f00022b0208657468657265756d06726576657274000008657468657265756d0c73746f7261676553746f72650001030201000503010001071102046d61696e0002066d656d6f727902000a16011401027f410021004120210110002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x0a"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportSelfDestructTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportSelfDestructTwoParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportSelfDestructTwoParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportSelfDestructTwoParamsFiller.yml",
+            "sourceHash" : "d1e2904a31d28d0ef2bdaef7eb7c94575bf5010cfb0cc21286f085713ffa3731"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xa91a256bf9fb30650ea62acfa371eaa4c1d700f8d5d9bff1e8096118d90924f4",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260027f7f0060000002310208657468657265756d0c73656c664465737472756374000008657468657265756d0c73746f7261676553746f72650000030201010503010001071102046d61696e0002066d656d6f727902000a23012101047f410021004120210141c0002102410a21032002200310002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x0a"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportSelfDestructZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportSelfDestructZeroParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportSelfDestructZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportSelfDestructZeroParamsFiller.yml",
+            "sourceHash" : "b0a8a9e3fb67f54b4e7a29a6410554ef36ab68130622699b6e567cfa05e74372"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xd974755fe424ede1a07f78eb5a1ce36ebbc438d6e2c48e6dfc714893e51611d6",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260000060027f7f0002310208657468657265756d0c73656c664465737472756374000008657468657265756d0c73746f7261676553746f72650001030201000503010001071102046d61696e0002066d656d6f727902000a16011401027f410021004120210110002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xabcdef"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x0a"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageLoadOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageLoadOneParam.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportStorageLoadOneParam" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadOneParamFiller.yml",
+            "sourceHash" : "52a8ba6935e4236618997fc0cf60263b45a21085f631335b14c11df2465ca260"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x6e0c5cb34d0efc218ded2897e37ca09e415d82a32da8e808542a4dc63ef21129",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360017f0060027f7f0060000002300208657468657265756d0b73746f726167654c6f6164000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102046d61696e0002066d656d6f727902000a2b012901037f410021004120210141c00021022001410136020020024101360200200210002000200110010b0b26010041000b200000000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageLoadThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageLoadThreeParams.json
@@ -1,0 +1,64 @@
+{
+    "malformedImportStorageLoadThreeParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadThreeParamsFiller.yml",
+            "sourceHash" : "2942e1babb52ea7ef001efb0cdae063ba56d76c248d5919187d23268b5871df3"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xaa78264601aaac0f150cdd7a6ea483c24555fedb022220dc90ed5df83b9fb672",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010f0360037f7f7f0060027f7f0060000002300208657468657265756d0b73746f726167654c6f6164000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102046d61696e0002066d656d6f727902000a39013701057f410021004120210141c000210241e00021034180012104200141013602002002410a36020020022003200410002000200110010b0b26010041000b200000000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x0a" : "0xdeadbeef"
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageLoadZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageLoadZeroParams.json
@@ -1,0 +1,63 @@
+{
+    "malformedImportStorageLoadZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadZeroParamsFiller.yml",
+            "sourceHash" : "e3ff6da9c64fd740fdbc2f06ac3aec46ff5f89b0341158a9595ec57f6e27a00a"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x32766640b58d4d6541dd8fd13b2f66175424540c2e8f116ef604ac2a3b0ea5d8",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260000060027f7f0002300208657468657265756d0b73746f726167654c6f6164000008657468657265756d0c73746f7261676553746f72650001030201000503010001071102046d61696e0002066d656d6f727902000a16011401027f410021004120210110002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageStoreOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageStoreOneParam.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportStorageStoreOneParam" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreOneParamFiller.yml",
+            "sourceHash" : "4fa8e9471c74a67c1dca3ad64d8acf1497352e07251faeabc9e749056e496677"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xe7dd8bb9711ebae5f62baebfc1e4bf033b1b6b3c4a9d4145475ced47285d5fff",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360017f0060027f7f0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102046d61696e0002066d656d6f727902000a18011601027f4100210041202101200010002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageStoreThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageStoreThreeParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportStorageStoreThreeParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreThreeParamsFiller.yml",
+            "sourceHash" : "11ec858cb9b9e3ba1284fff6f44dccf91eade001e4567562640266a0f213df2f"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xce97304d8628f73769254b5ebfe2a0d16fea36535fe85d5b9d51132dc50234ff",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010f0360037f7f7f0060027f7f0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102046d61696e0002066d656d6f727902000a28012601037f410021004120210141c00021022002410236020020002001200210002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageStoreZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageStoreZeroParams.json
@@ -1,0 +1,70 @@
+{
+    "malformedImportStorageStoreZeroParams" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.5.0-alpha.6",
+            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreZeroParamsFiller.yml",
+            "sourceHash" : "9950f50317b7c2de6a7b735bc7476d175c813086af04574f6505790e7951078a"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x8b77b4b4688fbdc1ed2229e05076709c8f24347fd181b3e46e0e423be3a12f9a",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001090260000060027f7f0002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c73746f7261676553746f72650001030201000503010001071102046d61696e0002066d656d6f727902000a16011401027f410021004120210110002000200110010b0b4b020041000b2000000000000000000000000000000000000000000000000000000000000000000041200b200100000000000000000000000000000000000000000000000000000000000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyFourParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyFourParamsFiller.yml
@@ -1,0 +1,76 @@
+# malformed import test for returnDataCopy, four params
+---
+malformedImportReturnDataCopyFourParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "returnDataCopy" (func $returnDataCopy (param i32 i32 i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $resultOffset i32)
+            (local $dataOffset i32)
+            (local $length i32)
+            (local $invalidParam i32)
+            
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+            (set_local $resultOffset (i32.const 64))
+            (set_local $dataOffset (i32.const 96))
+
+            (set_local $length (i32.const 10))
+            (set_local $invalidParam (i32.const 10))
+
+            (call $returnDataCopy (get_local $resultOffset) (get_local $dataOffset) (get_local $length) (get_local $invalidParam))
+            
+            ;; this storageStore should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00'         # should not store anything here since returnDataCopy fails prior to the storageStore execution
+          }
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '10'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyOneParamFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyOneParamFiller.yml
@@ -1,0 +1,69 @@
+# malformed import test for returnDataCopy, one param
+---
+malformedImportReturnDataCopyOneParam:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "returnDataCopy" (func $returnDataCopy (param i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $resultOffset i32)
+            
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+            (set_local $resultOffset (i32.const 64))
+
+            (call $returnDataCopy (get_local $resultOffset))
+            
+            ;; this storageStore should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00'         # should not store anything here since returnDataCopy fails prior to the storageStore execution
+          }
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '10'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyTwoParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyTwoParamsFiller.yml
@@ -1,0 +1,71 @@
+# malformed import test for returnDataCopy, two params
+---
+malformedImportReturnDataCopyTwoParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "returnDataCopy" (func $returnDataCopy (param i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $resultOffset i32)
+            (local $dataOffset i32)
+            
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+            (set_local $resultOffset (i32.const 64))
+            (set_local $dataOffset (i32.const 96))
+
+            (call $returnDataCopy (get_local $resultOffset) (get_local $dataOffset))
+            
+            ;; this storageStore should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00'         # should not store anything here since returnDataCopy fails prior to the storageStore execution
+          }
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '10'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyZeroParamsFiller.yml
@@ -1,0 +1,67 @@
+# malformed import test for returnDataCopy, zero params
+---
+malformedImportReturnDataCopyZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "returnDataCopy" (func $returnDataCopy))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            (call $returnDataCopy)
+            
+            ;; this storageStore should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00'         # should not store anything here since returnDataCopy fails prior to the storageStore execution
+          }
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '10'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertOneParamFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertOneParamFiller.yml
@@ -1,0 +1,70 @@
+# malformed import test for revert, using one param
+---
+malformedImportRevertOneParam:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "revert" (func $revert (param i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 64) "\ab\cd\ef")
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $dataOffset i32)
+            
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+            (set_local $dataOffset (i32.const 64))
+
+            (call $revert (get_local $dataOffset))
+            
+            ;; this storageStore should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00'         # should not store anything here since revert fails prior to the storageStore execution
+          }
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '10'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertThreeParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertThreeParamsFiller.yml
@@ -1,0 +1,75 @@
+# malformed import test for revert, using three params
+---
+malformedImportRevertThreeParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "revert" (func $revert (param i32 i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 64) "\ab\cd\ef")
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $dataOffset i32)
+            (local $length i32)
+            (local $invalidParam i32)
+            
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+            (set_local $dataOffset (i32.const 64))
+
+            (set_local $length (i32.const 3))
+            (set_local $invalidParam (i32.const 10))
+
+            (call $revert (get_local $dataOffset) (get_local $length) (get_local $invalidParam))
+            
+            ;; this storageStore should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00'         # should not store anything here since revert fails prior to the storageStore execution
+          }
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '10'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertZeroParamsFiller.yml
@@ -1,0 +1,68 @@
+# malformed import test for revert, using zero params
+---
+malformedImportRevertZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "revert" (func $revert))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            
+            (call $revert)
+            
+            ;; this storageStore should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00'         # should not store anything here since revert fails prior to the storageStore execution
+          }
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '10'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportSelfDestructTwoParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportSelfDestructTwoParamsFiller.yml
@@ -1,0 +1,72 @@
+# malformed import test for selfDestruct, using two params
+---
+malformedImportSelfDestructTwoParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "selfDestruct" (func $selfDestruct (param i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $addrOffset i32)
+            (local $invalidParam i32)
+            
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+            (set_local $addrOffset (i32.const 64))
+
+            (set_local $invalidParam (i32.const 10))
+
+            (call $selfDestruct (get_local $addrOffset) (get_local $invalidParam))
+            
+            ;; this storageStore should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00'         # should not store anything here since selfDestruct fails prior to the storageStore execution
+          }
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '10'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportSelfDestructZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportSelfDestructZeroParamsFiller.yml
@@ -1,0 +1,67 @@
+# malformed import test for selfDestruct, using zero params
+---
+malformedImportSelfDestructZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "selfDestruct" (func $selfDestruct))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            (call $selfDestruct)
+            
+            ;; this storageStore should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x00'         # should not store anything here since selfDestruct fails prior to the storageStore execution
+          }
+  transaction:
+    data:
+    - '0xabcdef'
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '10'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadOneParamFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadOneParamFiller.yml
@@ -1,0 +1,73 @@
+# malformed import test for storageLoad, using one param
+---
+malformedImportStorageLoadOneParam:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageLoad" (func $storageLoad (param i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          ;; storage key
+          (data (i32.const 0) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $pathOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+            (set_local $pathOffset (i32.const 64))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value 1
+            (i32.store (get_local $pathOffset) (i32.const 1)) ;; key 1
+
+            ;; this should throw an InvalidParams Exception
+            (call $storageLoad (get_local $pathOffset))
+
+            ;; this should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since wrong storageLoad fails prior to the correct storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadThreeParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadThreeParamsFiller.yml
@@ -1,0 +1,80 @@
+# malformed import test for storageLoad, using three params
+---
+malformedImportStorageLoadThreeParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageLoad" (func $storageLoad (param i32 i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          ;; storage key
+          (data (i32.const 0) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $pathOffset i32)
+            (local $resultOffset i32)
+            (local $wrongParam i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+            (set_local $pathOffset (i32.const 64))
+            (set_local $resultOffset (i32.const 96))
+            (set_local $wrongParam (i32.const 128))
+
+            (i32.store (get_local $valOffset) (i32.const 1)) ;; value 1
+            
+            (i32.store (get_local $pathOffset) (i32.const 10)) ;; storage path to load the data from
+
+            ;; this should throw an InvalidParams Exception
+            (call $storageLoad (get_local $pathOffset) (get_local $resultOffset) (get_local $wrongParam))
+
+            ;; this should not be called because of the previous failure
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00",
+        10: "0xdeadbeef"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0',         # should not store anything here since storageLoad fails prior to the storageStore execution
+            10: '0xdeadbeef'
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadZeroParamsFiller.yml
@@ -1,0 +1,68 @@
+# malformed import test for storageLoad, using zero params
+---
+malformedImportStorageLoadZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageLoad" (func $storageLoad))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            ;; this should throw an InvalidParams Exception
+            (call $storageLoad)
+
+            ;; this should not be called because of failure in previous storageLoad
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {
+        0: "0x00"
+      }
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since wrong storageLoad fails prior to the correct storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreOneParamFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreOneParamFiller.yml
@@ -1,0 +1,72 @@
+# malformed import test for storageStore, using one param
+---
+malformedImportStorageStoreOneParam:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $wrongStorageStore (param i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            ;; this should throw an InvalidParams Exception
+            (call $wrongStorageStore (get_local $keyOffset))
+
+            ;; this correct storage storage should not be called because of failure in previous one
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module)
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since wrong storageStore fails prior to the correct storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreThreeParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreThreeParamsFiller.yml
@@ -1,0 +1,76 @@
+# malformed import test for storageStore, using Three params
+---
+malformedImportStorageStoreThreeParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $wrongStorageStore (param i32 i32 i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+            (local $wrongParam i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+            (set_local $wrongParam (i32.const 64))
+
+            (i32.store (get_local $wrongParam) (i32.const 2)) ;; wrong parameter with value 2
+
+            ;; this should throw an InvalidParams Exception
+            (call $wrongStorageStore (get_local $keyOffset) (get_local $valOffset) (get_local $wrongParam))
+
+            ;; this correct storage storage should not be called because of failure in previous one
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module)
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since wrong storageStore fails prior to the correct storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreZeroParamsFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreZeroParamsFiller.yml
@@ -1,0 +1,72 @@
+# malformed import test for storageStore, using zero params
+---
+malformedImportStorageStoreZeroParams:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0'
+      storage: {}
+    b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $wrongStorageStore))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (memory 1)
+          (data (i32.const 0)  "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key 0
+          (data (i32.const 32) "\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; value 1
+          (export "main" (func $main))
+          (export "memory" (memory 0))
+          (func $main
+            (local $keyOffset i32)
+            (local $valOffset i32)
+
+            (set_local $keyOffset (i32.const 0))
+            (set_local $valOffset (i32.const 32))
+
+            ;; this should throw an InvalidParams Exception
+            (call $wrongStorageStore)
+
+            ;; this correct storage storage should not be called because of the previous exception
+            (call $storageStore (get_local $keyOffset) (get_local $valOffset))))
+      nonce: ''
+      storage: {}
+    deadbeef00000000000000000000000000000001:
+      balance: '100000000000'
+      code: |
+        (module)
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas:  !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        b94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          storage: {
+            0: '0x0' # should not store anything here since wrong storageStore fails prior to the correct storageStore execution
+          }
+  transaction:
+    data:
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'b94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    value:
+    - '0'


### PR DESCRIPTION
This PR contains the following test cases for malformed imports:

- [X] malformedImportReturnDataCopyFourParams
- [X] malformedImportReturnDataCopyOneParam
- [X] malformedImportReturnDataCopyTwoParams
- [X] malformedImportReturnDataCopyZeroParams
- [X] malformedImportRevertOneParam
- [X] malformedImportRevertThreeParams
- [X] malformedImportRevertZeroParams
- [X] malformedImportSelfDestructTwoParams
- [X] malformedImportSelfDestructZeroParams
- [X] malformedImportStorageLoadOneParam
- [X] malformedImportStorageLoadThreeParams
- [X] malformedImportStorageLoadZeroParams
- [X] malformedImportStorageStoreOneParam
- [X] malformedImportStorageStoreThreeParams
- [X] malformedImportStorageStoreZeroParams