### PR TITLE
coverage tests: create with not enough balance

### DIFF
--- a/GeneralStateTests/stEWASMTests/createNotEnoughBalance.json
+++ b/GeneralStateTests/stEWASMTests/createNotEnoughBalance.json
@@ -1,0 +1,70 @@
+{
+    "createNotEnoughBalance" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0rc6+commit.d7e94caa.dirty",
+            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/createNotEnoughBalanceFiller.yml",
+            "sourceHash" : "19253383b0da9775505a2639ceff97c98415ce7d1394da00927785e9bef278fd"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x3f22827ef2feae7531c843b6efd485451e2b60fe7f6a1d290255a6e1caa27f67",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa000000000000000000000000000000000000001" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d01000000010d0360027f7f0060017f0060000002310208657468657265756d0c73746f7261676553746f7265000008657468657265756d0c67657443616c6c56616c75650001030201020503010001071102066d656d6f72790200046d61696e00020a1a011801027f418004210041a0042101200010012001200010000b0b27010041a0040b200000000000000000000000000000000000000000000000000000000000000002",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x04",
+                "storage" : {
+                }
+            },
+            "0xdeadbeef00000000000000000000000000000000" : {
+                "balance" : "0x00",
+                "code" : "0x0061736d0100000001180460047f7f7f7f017f60017f017f60047f7f7f7f00600000024e0308657468657265756d06637265617465000008657468657265756d1367657445787465726e616c436f646553697a65000108657468657265756d1065787465726e616c436f6465436f70790002030201030503010001071102066d656d6f72790200046d61696e00030a3c013a01067f410021014120210341c000210441e00021054180022102200110012100200120024100200010022003200420022000200510003602000b0b34020041000b14a0000000000000000000000000000000000000010041c0000b14000000000000000000000000000000174876e800",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x6acfc0"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x04",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xdeadbeef00000000000000000000000000000000",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/src/GeneralStateTestsFiller/stEWASMTests/createNotEnoughBalanceFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/createNotEnoughBalanceFiller.yml
@@ -1,0 +1,121 @@
+# Try to create a new contract, and sending a value higher than current balance
+createNotEnoughBalance:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: '0x4'
+      storage: {}
+    a000000000000000000000000000000000000001:
+      balance: '100000000000'
+      nonce: ''
+      storage: {}
+      code: |
+        (module
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+          (import "ethereum" "getCallValue" (func $getCallValue (param i32)))
+          (memory 1)
+          ;; storage key
+          (data (i32.const 544) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02") ;; 2
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; locals
+            (local $memPointerCallValue i32)
+            (local $memPointerStorageKey3 i32)
+
+            ;; memory
+            (set_local $memPointerCallValue (i32.const 512))
+            (set_local $memPointerStorageKey3 (i32.const 544))
+
+            ;; get and write the call value to memory
+            (call $getCallValue (get_local $memPointerCallValue))
+
+            ;; store it
+            (call $storageStore
+              (get_local $memPointerStorageKey3)
+              (get_local $memPointerCallValue)
+            )
+            ;; no return value, we're not setting any code
+          )
+        )
+    deadbeef00000000000000000000000000000000:
+      balance: '0'
+      nonce: ''
+      storage: {}
+      code: |
+        (module
+          (import "ethereum" "create" (func $create (param i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "getExternalCodeSize" (func $getExternalCodeSize (param i32) (result i32)))
+          (import "ethereum" "externalCodeCopy" (func $externalCodeCopy (param i32 i32 i32 i32)))          
+          (memory 1 )
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+          (data (i32.const 0) "\a0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01")
+          (data (i32.const 64) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\17\48\76\e8\00")
+          (func $main
+            (local $codeLen i32)
+            (local $addrOffset i32)
+            (local $codeMemLoc i32)
+            (local $retCode    i32)
+            (local $valOffset  i32)
+            (local $createResult i32)
+
+            (set_local $addrOffset (i32.const 0))
+            (set_local $retCode (i32.const 32))
+            (set_local $valOffset (i32.const 64))
+            (set_local $createResult (i32.const 96))
+            (set_local $codeMemLoc (i32.const 256))
+            
+
+            ;; get external code length
+            (set_local $codeLen
+              (call $getExternalCodeSize (get_local $addrOffset)))
+
+            ;; get external code
+            (call $externalCodeCopy
+              (get_local $addrOffset) ;; address
+              (get_local $codeMemLoc) ;; result
+              (i32.const 0)           ;; code offset
+              (get_local $codeLen))   ;; code length
+              
+            (i32.store (get_local $retCode) ;; store result value
+              (call $create
+                (get_local $valOffset)
+                (get_local $codeMemLoc)
+                (get_local $codeLen)
+                (get_local $createResult)))
+          )
+        )
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99999977582'
+        deadbeef00000000000000000000000000000000:
+          storage: {
+          }
+  transaction:
+    data:
+    - '0x'
+    gasLimit:
+    - '0x6acfc0'
+    gasPrice: '0x01'
+    nonce: '0x04'
+    secretKey: "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    to: 'deadbeef00000000000000000000000000000000'
+    value:
+    - '0'


### PR DESCRIPTION
Test case requested in: https://github.com/ewasm/hera/issues/399#issuecomment-422754891

There are 2 pending test cases: call depth > 1024, create depth > 1024, I already wrote those test cases but after executing it runs Out Of Gas, even if I set the maximum amount as gasLimit for the transaction, the gas is not enough to execute 1024 calls/create depth.

Maximum Depth for call: 928
Maximum Depth for create: 683