### PR TITLE
Add a few more tests for valid Ewasm bytecode

### DIFF
--- a/GeneralStateTests/stEWASMTests/validateBytecodeBadVersionFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeBadVersionFromTxIsInvalid.json
@@ -1,0 +1,56 @@
+{
+    "validateBytecodeBadVersionFromTxIsInvalid" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeBadVersionFromTxIsInvalidFiller.yml",
+            "sourceHash" : "99e6ca7196868883b0f2388bebca5a2ff7a37f44063ca6add4bf387f16be3811"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x60f7870ae7c1fb1176a96382cbfe1c1dfc83cb08081728a7396e901a70832a36",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x0061736d02000000"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/validateBytecodeBadVersionIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeBadVersionIsInvalid.json
@@ -1,0 +1,63 @@
+{
+    "validateBytecodeBadVersionIsInvalid" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeBadVersionIsInvalidFiller.yml",
+            "sourceHash" : "354346c2591fa0d0f7fdede9a63212429678f3decfb9d0b19a0f33e7b4e667ae"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xc86695425e41abae8702ed7bf80bab7cc71478ab69fe706c79fdbd7c9efa0c2a",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001110360047f7f7f7f017f60027f7f00600000022b0208657468657265756d06637265617465000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102066d656d6f72790200046d61696e00020a41013f01077f410021004120210141c000210241e000210341800121044180022105410821062003200420052006200110003602002000200110012002200310010b0b5a030041000b2000000000000000000000000000000000000000000000000000000000000000000041c0000b200000000000000000000000000000000000000000000000000000000000000001004180020b080061736d02000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/validateBytecodeEmptyInitFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeEmptyInitFromTxIsInvalid.json
@@ -1,0 +1,56 @@
+{
+    "validateBytecodeEmptyInitFromTxIsInvalid" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeEmptyInitFromTxIsInvalidFiller.yml",
+            "sourceHash" : "0a971f4c720d27b3089e38571e6702d60d89ace44b1f30a9447a588e3fce6986"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x60f7870ae7c1fb1176a96382cbfe1c1dfc83cb08081728a7396e901a70832a36",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x0061736d01000000"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/validateBytecodeEmptyInitIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeEmptyInitIsInvalid.json
@@ -1,0 +1,63 @@
+{
+    "validateBytecodeEmptyInitIsInvalid" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeEmptyInitIsInvalidFiller.yml",
+            "sourceHash" : "8b32d5604a8d9075e565197a08c4babd2f0d0e5b80ae42980f53f239e0fbf397"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xc957e9dce643426b1a75cee50d932e82d79cf087973caf588572e92291585595",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001110360047f7f7f7f017f60027f7f00600000022b0208657468657265756d06637265617465000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102066d656d6f72790200046d61696e00020a41013f01077f410021004120210141c000210241e000210341800121044180022105410821062003200420052006200110003602002000200110012002200310010b0b5a030041000b2000000000000000000000000000000000000000000000000000000000000000000041c0000b200000000000000000000000000000000000000000000000000000000000000001004180020b080061736d01000000",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionFromTxIsInvalid.json
@@ -1,0 +1,56 @@
+{
+    "validateBytecodeMissingVersionFromTxIsInvalid" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionFromTxIsInvalidFiller.yml",
+            "sourceHash" : "c0365c60399c43b2846b24bae1ad65e9e1578019576ecd6912b6ce30919970bf"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x60f7870ae7c1fb1176a96382cbfe1c1dfc83cb08081728a7396e901a70832a36",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x0061736d"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionIsInvalid.json
@@ -1,0 +1,63 @@
+{
+    "validateBytecodeMissingVersionIsInvalid" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionIsInvalidFiller.yml",
+            "sourceHash" : "bb36b238295f2f64734651cba26d3b848e7f2bddfac0fb67bab806c0080a48d9"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0xed1472fcdc2db5ce406714c4b2af88c2a602a531ec1bcdcc01ad298137d64bd4",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001110360047f7f7f7f017f60027f7f00600000022b0208657468657265756d06637265617465000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102066d656d6f72790200046d61696e00020a41013f01077f410021004120210141c000210241e000210341800121044180022105410421062003200420052006200110003602002000200110012002200310010b0b56030041000b2000000000000000000000000000000000000000000000000000000000000000000041c0000b200000000000000000000000000000000000000000000000000000000000000001004180020b040061736d",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionOneByteIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionOneByteIsInvalid.json
@@ -1,0 +1,63 @@
+{
+    "validateBytecodeMissingVersionOneByteIsInvalid" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionOneByteIsInvalidFiller.yml",
+            "sourceHash" : "f98fd476237ab7eb0f2ce25eb7f615bcc73b7e95440e3ff6f41ff0a13230573c"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x1e300b2ae779a328df7ce67eb62ba9dacf857ddb32290de458f9f3ce2b94ce10",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001110360047f7f7f7f017f60027f7f00600000022b0208657468657265756d06637265617465000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102066d656d6f72790200046d61696e00020a41013f01077f410021004120210141c000210241e000210341800121044180022105410521062003200420052006200110003602002000200110012002200310010b0b57030041000b2000000000000000000000000000000000000000000000000000000000000000000041c0000b200000000000000000000000000000000000000000000000000000000000000001004180020b050061736d01",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalid.json
@@ -1,0 +1,56 @@
+{
+    "validateBytecodeMissingVersionTwoBytesFromTxIsInvalid" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalidFiller.yml",
+            "sourceHash" : "7ce371d4bf019025a31fb7a1bc9e49ca5800489eef9d16726fbc08ee5a8ef635"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x60f7870ae7c1fb1176a96382cbfe1c1dfc83cb08081728a7396e901a70832a36",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x0061736d0100"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionTwoBytesIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionTwoBytesIsInvalid.json
@@ -1,0 +1,63 @@
+{
+    "validateBytecodeMissingVersionTwoBytesIsInvalid" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "testeth 1.4.0",
+            "lllcversion" : "Version: 0.4.20-develop.2018.1.14+commit.0c20b6da.Darwin.appleclang",
+            "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesIsInvalidFiller.yml",
+            "sourceHash" : "008b86503ed51eaa425c138a9f348768fa1876e854625dc5d034a7d141137e07"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05500000",
+            "currentNumber" : "0x01",
+            "currentTimestamp" : "0x03e8",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Byzantium" : [
+                {
+                    "hash" : "0x9395e4cc859ffba06ebf2e9b5f7e6b435655351df58b015ea1d832cf4aba3b67",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x174876e800",
+                "code" : "",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" : {
+                "balance" : "0x174876e800",
+                "code" : "0x0061736d0100000001110360047f7f7f7f017f60027f7f00600000022b0208657468657265756d06637265617465000008657468657265756d0c73746f7261676553746f72650001030201020503010001071102066d656d6f72790200046d61696e00020a41013f01077f410021004120210141c000210241e000210341800121044180022105410621062003200420052006200110003602002000200110012002200310010b0b58030041000b2000000000000000000000000000000000000000000000000000000000000000000041c0000b200000000000000000000000000000000000000000000000000000000000000001004180020b060061736d0100",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x"
+            ],
+            "gasLimit" : [
+                "0x5000001"
+            ],
+            "gasPrice" : "0x01",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeBadVersionFromTxIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeBadVersionFromTxIsInvalidFiller.yml
@@ -1,0 +1,43 @@
+# Test that init bytecode (with magic + invalid version) from tx is invalid
+validateBytecodeBadVersionFromTxIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        # newly-created contract
+        # expect code to be empty since create should fail
+        6295ee1b4f6dd65047762f924ecd367c17eabf8f:
+          shouldnotexist: 1
+  transaction:
+    data: [
+      # Wasm magic (0061736d) followed by invalid version number, little-endian (02000000)
+      "0x0061736d02000000"
+    ]
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: ''
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeBadVersionIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeBadVersionIsInvalidFiller.yml
@@ -1,0 +1,108 @@
+# Test that bytecode (with magic + invalid Wasm version) is invalid
+validateBytecodeBadVersionIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+    # main contract, tx receiver
+    abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "create" (func $create (param i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+
+          (memory 1)
+          ;; the inner contract to create
+          ;; see WASM source for compiled code, above
+          (data (i32.const 0) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key1
+          (data (i32.const 64) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01") ;; key2 
+          (data (i32.const 256) "\00\61\73\6d\02\00\00\00") ;; init code, contains version == 2, which is invalid for Ewasm
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; memory layout
+            (local $memStoragekey1 i32)
+            (local $memStorageval1 i32)
+            (local $memStoragekey2 i32)
+            (local $memStorageval2 i32)
+            (local $memValue i32)
+            (local $memCode i32)
+            (local $codeLen i32)
+
+            (set_local $memStoragekey1 (i32.const 0))
+            (set_local $memStorageval1 (i32.const 32))
+            (set_local $memStoragekey2 (i32.const 64))
+            (set_local $memStorageval2 (i32.const 96))
+            (set_local $memValue (i32.const 128))
+            (set_local $memCode (i32.const 256))
+            (set_local $codeLen (i32.const 8))
+
+            ;; we expect this to fail
+            (i32.store
+              (get_local $memStorageval2)
+              (call $create
+                ;; value offset
+                (get_local $memValue)
+                ;; data offset
+                (get_local $memCode)
+                ;; data length
+                (get_local $codeLen)
+                ;; result offset (new contract address)
+                (get_local $memStorageval1)
+              )
+            )
+
+            ;; store the result (new contract address)
+            (call $storageStore
+              (get_local $memStoragekey1)
+              (get_local $memStorageval1)
+            )
+
+            ;; store the result of the CREATE
+            (call $storageStore
+              (get_local $memStoragekey2)
+              (get_local $memStorageval2)
+            )
+          )
+        )
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99917398810'
+        abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+          # expect CREATE to return 1 (failure), and no created contract address
+          storage: {
+            0: '',
+            1: '0x0100000000000000000000000000000000000000000000000000000000000000',
+          }
+  transaction:
+    data: 
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeEmptyInitFromTxIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeEmptyInitFromTxIsInvalidFiller.yml
@@ -1,0 +1,45 @@
+# Test that empty init bytecode (with magic + version) from tx is invalid (because `main` is missing)
+validateBytecodeEmptyInitFromTxIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        # newly-created contract
+        # expect code to be empty since create should fail
+        6295ee1b4f6dd65047762f924ecd367c17eabf8f:
+          shouldnotexist: 1
+  transaction:
+    data: 
+    - |
+      (module
+        ;; empty bytecode
+        ;; no "main" export
+      )
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: ''
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeEmptyInitIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeEmptyInitIsInvalidFiller.yml
@@ -1,0 +1,111 @@
+# Test that empty init bytecode (with magic + version) is invalid (because `main` is missing)
+validateBytecodeEmptyInitIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+    # WASM source for compiled code, below:
+    #   code: |
+    #     (module)
+    # main contract, tx receiver
+    abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "create" (func $create (param i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+
+          (memory 1)
+          ;; the inner contract to create
+          ;; see WASM source for compiled code, above
+          (data (i32.const 0) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key1
+          (data (i32.const 64) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01") ;; key2 
+          (data (i32.const 256) "\00\61\73\6d\01\00\00\00") ;; init code
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; memory layout
+            (local $memStoragekey1 i32)
+            (local $memStorageval1 i32)
+            (local $memStoragekey2 i32)
+            (local $memStorageval2 i32)
+            (local $memValue i32)
+            (local $memCode i32)
+            (local $codeLen i32)
+
+            (set_local $memStoragekey1 (i32.const 0))
+            (set_local $memStorageval1 (i32.const 32))
+            (set_local $memStoragekey2 (i32.const 64))
+            (set_local $memStorageval2 (i32.const 96))
+            (set_local $memValue (i32.const 128))
+            (set_local $memCode (i32.const 256))
+            (set_local $codeLen (i32.const 8))
+
+            ;; we expect this to fail
+            (i32.store
+              (get_local $memStorageval2)
+              (call $create
+                ;; value offset
+                (get_local $memValue)
+                ;; data offset
+                (get_local $memCode)
+                ;; data length
+                (get_local $codeLen)
+                ;; result offset (new contract address)
+                (get_local $memStorageval1)
+              )
+            )
+
+            ;; store the result (new contract address)
+            (call $storageStore
+              (get_local $memStoragekey1)
+              (get_local $memStorageval1)
+            )
+
+            ;; store the result of the CREATE
+            (call $storageStore
+              (get_local $memStoragekey2)
+              (get_local $memStorageval2)
+            )
+          )
+        )
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99917398810'
+        abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+          # expect CREATE to return 1 (failure), and no created contract address
+          storage: {
+            0: '',
+            1: '0x0100000000000000000000000000000000000000000000000000000000000000',
+          }
+  transaction:
+    data: 
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionFromTxIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionFromTxIsInvalidFiller.yml
@@ -1,0 +1,43 @@
+# Test that init bytecode (with magic + missing version) from tx is invalid
+validateBytecodeMissingVersionFromTxIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        # newly-created contract
+        # expect code to be empty since create should fail
+        6295ee1b4f6dd65047762f924ecd367c17eabf8f:
+          shouldnotexist: 1
+  transaction:
+    data: [
+      # Wasm magic (0061736d) with no following version number
+      "0x0061736d"
+    ]
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: ''
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionIsInvalidFiller.yml
@@ -1,0 +1,108 @@
+# Test that bytecode (with magic + missing Wasm version) is invalid
+validateBytecodeMissingVersionIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+    # main contract, tx receiver
+    abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "create" (func $create (param i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+
+          (memory 1)
+          ;; the inner contract to create
+          ;; see WASM source for compiled code, above
+          (data (i32.const 0) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key1
+          (data (i32.const 64) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01") ;; key2 
+          (data (i32.const 256) "\00\61\73\6d") ;; init code, missing version number
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; memory layout
+            (local $memStoragekey1 i32)
+            (local $memStorageval1 i32)
+            (local $memStoragekey2 i32)
+            (local $memStorageval2 i32)
+            (local $memValue i32)
+            (local $memCode i32)
+            (local $codeLen i32)
+
+            (set_local $memStoragekey1 (i32.const 0))
+            (set_local $memStorageval1 (i32.const 32))
+            (set_local $memStoragekey2 (i32.const 64))
+            (set_local $memStorageval2 (i32.const 96))
+            (set_local $memValue (i32.const 128))
+            (set_local $memCode (i32.const 256))
+            (set_local $codeLen (i32.const 4))
+
+            ;; we expect this to fail
+            (i32.store
+              (get_local $memStorageval2)
+              (call $create
+                ;; value offset
+                (get_local $memValue)
+                ;; data offset
+                (get_local $memCode)
+                ;; data length
+                (get_local $codeLen)
+                ;; result offset (new contract address)
+                (get_local $memStorageval1)
+              )
+            )
+
+            ;; store the result (new contract address)
+            (call $storageStore
+              (get_local $memStoragekey1)
+              (get_local $memStorageval1)
+            )
+
+            ;; store the result of the CREATE
+            (call $storageStore
+              (get_local $memStoragekey2)
+              (get_local $memStorageval2)
+            )
+          )
+        )
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99917398810'
+        abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+          # expect CREATE to return 1 (failure), and no created contract address
+          storage: {
+            0: '',
+            1: '0x0100000000000000000000000000000000000000000000000000000000000000',
+          }
+  transaction:
+    data: 
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionOneByteFromTxIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionOneByteFromTxIsInvalidFiller.yml
@@ -1,0 +1,43 @@
+# Test that init bytecode (with magic + one byte version) from tx is invalid
+validateBytecodeMissingVersionOneByteFromTxIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        # newly-created contract
+        # expect code to be empty since create should fail
+        6295ee1b4f6dd65047762f924ecd367c17eabf8f:
+          shouldnotexist: 1
+  transaction:
+    data: [
+      # Wasm magic (0061736d) with only one byte for version number
+      "0x0061736d01"
+    ]
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: ''
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionOneByteIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionOneByteIsInvalidFiller.yml
@@ -1,0 +1,108 @@
+# Test that bytecode (with magic + one byte Wasm version) is invalid
+validateBytecodeMissingVersionOneByteIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+    # main contract, tx receiver
+    abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "create" (func $create (param i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+
+          (memory 1)
+          ;; the inner contract to create
+          ;; see WASM source for compiled code, above
+          (data (i32.const 0) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key1
+          (data (i32.const 64) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01") ;; key2 
+          (data (i32.const 256) "\00\61\73\6d\01") ;; init code, missing version number
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; memory layout
+            (local $memStoragekey1 i32)
+            (local $memStorageval1 i32)
+            (local $memStoragekey2 i32)
+            (local $memStorageval2 i32)
+            (local $memValue i32)
+            (local $memCode i32)
+            (local $codeLen i32)
+
+            (set_local $memStoragekey1 (i32.const 0))
+            (set_local $memStorageval1 (i32.const 32))
+            (set_local $memStoragekey2 (i32.const 64))
+            (set_local $memStorageval2 (i32.const 96))
+            (set_local $memValue (i32.const 128))
+            (set_local $memCode (i32.const 256))
+            (set_local $codeLen (i32.const 5))
+
+            ;; we expect this to fail
+            (i32.store
+              (get_local $memStorageval2)
+              (call $create
+                ;; value offset
+                (get_local $memValue)
+                ;; data offset
+                (get_local $memCode)
+                ;; data length
+                (get_local $codeLen)
+                ;; result offset (new contract address)
+                (get_local $memStorageval1)
+              )
+            )
+
+            ;; store the result (new contract address)
+            (call $storageStore
+              (get_local $memStoragekey1)
+              (get_local $memStorageval1)
+            )
+
+            ;; store the result of the CREATE
+            (call $storageStore
+              (get_local $memStoragekey2)
+              (get_local $memStorageval2)
+            )
+          )
+        )
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99917398810'
+        abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+          # expect CREATE to return 1 (failure), and no created contract address
+          storage: {
+            0: '',
+            1: '0x0100000000000000000000000000000000000000000000000000000000000000',
+          }
+  transaction:
+    data: 
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd'
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalidFiller.yml
@@ -1,0 +1,43 @@
+# Test that init bytecode (with magic + two byte version) from tx is invalid
+validateBytecodeMissingVersionTwoBytesFromTxIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99916113919'
+        # newly-created contract
+        # expect code to be empty since create should fail
+        6295ee1b4f6dd65047762f924ecd367c17eabf8f:
+          shouldnotexist: 1
+  transaction:
+    data: [
+      # Wasm magic (0061736d) with only one byte for version number
+      "0x0061736d0100"
+    ]
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: ''
+    value:
+    - '0'

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalidFiller.yml
@@ -30,7 +30,7 @@ validateBytecodeMissingVersionTwoBytesFromTxIsInvalid:
           shouldnotexist: 1
   transaction:
     data: [
-      # Wasm magic (0061736d) with only one byte for version number
+      # Wasm magic (0061736d) with only two bytes for version number
       "0x0061736d0100"
     ]
     gasLimit:

--- a/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesIsInvalidFiller.yml
+++ b/src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesIsInvalidFiller.yml
@@ -1,0 +1,108 @@
+# Test that bytecode (with magic + two byte Wasm version) is invalid
+validateBytecodeMissingVersionTwoBytesIsInvalid:
+  env:
+    currentCoinbase: 2adc25665018aa1fe0e6bc666dac8fc2697ff9ba
+    currentDifficulty: '0x020000'
+    currentGasLimit: '89128960'
+    currentNumber: '1'
+    currentTimestamp: '1000'
+    previousHash: 5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6
+  pre:
+    # tx sender
+    a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+      balance: '100000000000'
+      code: ''
+      nonce: ''
+      storage: {}
+    # main contract, tx receiver
+    abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+      balance: '100000000000'
+      code: |
+        (module
+          (import "ethereum" "create" (func $create (param i32 i32 i32 i32) (result i32)))
+          (import "ethereum" "storageStore" (func $storageStore (param i32 i32)))
+
+          (memory 1)
+          ;; the inner contract to create
+          ;; see WASM source for compiled code, above
+          (data (i32.const 0) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; key1
+          (data (i32.const 64) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01") ;; key2 
+          (data (i32.const 256) "\00\61\73\6d\01\00") ;; init code, missing version number
+          (export "memory" (memory 0))
+          (export "main" (func $main))
+
+          (func $main
+            ;; memory layout
+            (local $memStoragekey1 i32)
+            (local $memStorageval1 i32)
+            (local $memStoragekey2 i32)
+            (local $memStorageval2 i32)
+            (local $memValue i32)
+            (local $memCode i32)
+            (local $codeLen i32)
+
+            (set_local $memStoragekey1 (i32.const 0))
+            (set_local $memStorageval1 (i32.const 32))
+            (set_local $memStoragekey2 (i32.const 64))
+            (set_local $memStorageval2 (i32.const 96))
+            (set_local $memValue (i32.const 128))
+            (set_local $memCode (i32.const 256))
+            (set_local $codeLen (i32.const 6))
+
+            ;; we expect this to fail
+            (i32.store
+              (get_local $memStorageval2)
+              (call $create
+                ;; value offset
+                (get_local $memValue)
+                ;; data offset
+                (get_local $memCode)
+                ;; data length
+                (get_local $codeLen)
+                ;; result offset (new contract address)
+                (get_local $memStorageval1)
+              )
+            )
+
+            ;; store the result (new contract address)
+            (call $storageStore
+              (get_local $memStoragekey1)
+              (get_local $memStorageval1)
+            )
+
+            ;; store the result of the CREATE
+            (call $storageStore
+              (get_local $memStoragekey2)
+              (get_local $memStorageval2)
+            )
+          )
+        )
+      nonce: ''
+      storage: {}
+  expect:
+    - indexes:
+        data: !!int -1
+        gas: !!int -1
+        value: !!int -1
+      network:
+        - ALL
+      result:
+        a94f5374fce5edbc8e2a8697c15331677e6ebf0b:
+          balance: '99917398810'
+        abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd:
+          # expect CREATE to return 1 (failure), and no created contract address
+          storage: {
+            0: '',
+            1: '0x0100000000000000000000000000000000000000000000000000000000000000',
+          }
+  transaction:
+    data: 
+    - ''
+    gasLimit:
+    - '0x5000001'
+    gasPrice: '0x01'
+    nonce: '0x00'
+    secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8
+    to: 'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd'
+    value:
+    - '0'


### PR DESCRIPTION
Tests:
- [x] _emptyBytecode_ - Contract code has no sections, is exactly 8 bytes long (has the magic + version) (this is valid)
- [x] _invalidWasmVersion_ - Contract code has no sections, is exactly 8 bytes long (has the magic + version), and version != 1
- [x] _missingWasmVersion_ - Contract code has no sections, has the wasm magic, is 4-7 bytes long (has the magic, and no version, or too few version bytes)