### PR TITLE
Refill tests using testeth 1.6.0 and hera 0.2.3

### DIFF
--- a/GeneralStateTests/stEWASMTests/callCode.json
+++ b/GeneralStateTests/stEWASMTests/callCode.json
@@ -2,8 +2,8 @@
     "callCode" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callCodeFiller.yml",
             "sourceHash" : "d9d410d462615d4ebbbfcdb6e16de259a0eecbda6a7c2ad3939059424ceaf69a"
         },

--- a/GeneralStateTests/stEWASMTests/callCodeVeryLong.json
+++ b/GeneralStateTests/stEWASMTests/callCodeVeryLong.json
@@ -2,8 +2,8 @@
     "callCodeVeryLong" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callCodeVeryLongFiller.yml",
             "sourceHash" : "2c246f62d98ef47534ba1ce2e6bb92681ec1f89323e12d7892337461a769948b"
         },

--- a/GeneralStateTests/stEWASMTests/callData.json
+++ b/GeneralStateTests/stEWASMTests/callData.json
@@ -2,8 +2,8 @@
     "callData" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callDataFiller.yml",
             "sourceHash" : "4befdb1b7912b097db79515c6172b5c5e0a644d2ff4a5575710389c285da4f8f"
         },

--- a/GeneralStateTests/stEWASMTests/callDataCopy.json
+++ b/GeneralStateTests/stEWASMTests/callDataCopy.json
@@ -2,8 +2,8 @@
     "callDataCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callDataCopyFiller.yml",
             "sourceHash" : "6716deb099663503b87429aae65992609fcec713d6d7d12b502211d0e9d09d7d"
         },

--- a/GeneralStateTests/stEWASMTests/callDataCopy256.json
+++ b/GeneralStateTests/stEWASMTests/callDataCopy256.json
@@ -2,8 +2,8 @@
     "callDataCopy256" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callDataCopy256Filler.yml",
             "sourceHash" : "00c097114bf2403b65c994dcf6a7f683b95810ec86126e8847bf11053a9d902d"
         },

--- a/GeneralStateTests/stEWASMTests/callDataCopyInRust.json
+++ b/GeneralStateTests/stEWASMTests/callDataCopyInRust.json
@@ -2,8 +2,8 @@
     "callDataCopyInRust" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callDataCopyInRustFiller.yml",
             "sourceHash" : "467fb3c0550acdf9331b41bc345a53516235117e45d55ba60f8e987f02d3a247"
         },

--- a/GeneralStateTests/stEWASMTests/callDataValue.json
+++ b/GeneralStateTests/stEWASMTests/callDataValue.json
@@ -2,8 +2,8 @@
     "callDataValue" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callDataValueFiller.yml",
             "sourceHash" : "987ecf8718f57cd0d2bfc556bb04d95f96c00865021ac536c590f9b366a47457"
         },

--- a/GeneralStateTests/stEWASMTests/callDelegate.json
+++ b/GeneralStateTests/stEWASMTests/callDelegate.json
@@ -2,8 +2,8 @@
     "callDelegate" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callDelegateFiller.yml",
             "sourceHash" : "ba383e56d5f2c14597b354a5341e0576ace7eec9847d86c350f3c28d7617a4ad"
         },

--- a/GeneralStateTests/stEWASMTests/callDelegateOOG.json
+++ b/GeneralStateTests/stEWASMTests/callDelegateOOG.json
@@ -2,8 +2,8 @@
     "callDelegateOOG" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callDelegateOOGFiller.yml",
             "sourceHash" : "2056a4741888656c8f234dc191fe19e82a2609d3f6f2cf3d4cff8be91944a37f"
         },

--- a/GeneralStateTests/stEWASMTests/callDelegateVeryLong.json
+++ b/GeneralStateTests/stEWASMTests/callDelegateVeryLong.json
@@ -2,8 +2,8 @@
     "callDelegateVeryLong" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callDelegateVeryLongFiller.yml",
             "sourceHash" : "70699333fd533688e3218dd353a51550f07b78dc03f644600d99e444721f14bc"
         },

--- a/GeneralStateTests/stEWASMTests/callDepth.json
+++ b/GeneralStateTests/stEWASMTests/callDepth.json
@@ -2,8 +2,8 @@
     "callDepth" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callDepthFiller.yml",
             "sourceHash" : "13751dc847895f218bc8eb1b0556b0fbf2c8ae04ad4495811f89c227d50cc3cc"
         },

--- a/GeneralStateTests/stEWASMTests/callNoDataNoValue.json
+++ b/GeneralStateTests/stEWASMTests/callNoDataNoValue.json
@@ -2,8 +2,8 @@
     "callNoDataNoValue" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callNoDataNoValueFiller.yml",
             "sourceHash" : "fd3497f9331542915626cc9674aad317c7ca3ed54324585c56c613ce4db38115"
         },

--- a/GeneralStateTests/stEWASMTests/callOOB1.json
+++ b/GeneralStateTests/stEWASMTests/callOOB1.json
@@ -2,8 +2,8 @@
     "callOOB1" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callOOB1Filler.yml",
             "sourceHash" : "bdb5ac44f196d9370dc16c362350075ec06aedf56288599f75ebf53fc7da3551"
         },

--- a/GeneralStateTests/stEWASMTests/callOOB2.json
+++ b/GeneralStateTests/stEWASMTests/callOOB2.json
@@ -2,8 +2,8 @@
     "callOOB2" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callOOB2Filler.yml",
             "sourceHash" : "4c4f3d54d19247e9262aee536e849adf62f26f9edb7dd170f9264d8047bdf03c"
         },

--- a/GeneralStateTests/stEWASMTests/callOOB3.json
+++ b/GeneralStateTests/stEWASMTests/callOOB3.json
@@ -2,8 +2,8 @@
     "callOOB3" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callOOB3Filler.yml",
             "sourceHash" : "84341446f1578500df55bd9fd601dcc2a4b22af78c06870115dbf73517201c2f"
         },

--- a/GeneralStateTests/stEWASMTests/callSenderBalanceExceeds128Bits.json
+++ b/GeneralStateTests/stEWASMTests/callSenderBalanceExceeds128Bits.json
@@ -2,8 +2,8 @@
     "callSenderBalanceExceeds128Bits" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callSenderBalanceExceeds128BitsFiller.yml",
             "sourceHash" : "380857ae3fa454a84e4e004b9ecd77b150f6f6e71cea576b7511de671315be32"
         },

--- a/GeneralStateTests/stEWASMTests/callStatic.json
+++ b/GeneralStateTests/stEWASMTests/callStatic.json
@@ -2,8 +2,8 @@
     "callStatic" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callStaticFiller.yml",
             "sourceHash" : "575eff91cbd4a1e0457a85cfa93ec57a9bb917c96596e809e0054a041e57b86b"
         },

--- a/GeneralStateTests/stEWASMTests/callStaticVeryLong.json
+++ b/GeneralStateTests/stEWASMTests/callStaticVeryLong.json
@@ -2,8 +2,8 @@
     "callStaticVeryLong" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callStaticVeryLongFiller.yml",
             "sourceHash" : "7630de44fb343d368b45b4b82cc7af6983c88f8a750961a0026d3b8dea5f334d"
         },

--- a/GeneralStateTests/stEWASMTests/callValue.json
+++ b/GeneralStateTests/stEWASMTests/callValue.json
@@ -2,8 +2,8 @@
     "callValue" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callValueFiller.yml",
             "sourceHash" : "701cd21bc043407535d973e73f8ce75dcffcb775ed6e8b163b865b99e90f58a6"
         },

--- a/GeneralStateTests/stEWASMTests/callValueExceeds64bit.json
+++ b/GeneralStateTests/stEWASMTests/callValueExceeds64bit.json
@@ -2,8 +2,8 @@
     "callValueExceeds64bit" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callValueExceeds64bitFiller.yml",
             "sourceHash" : "db49d8aca73d38724a188ba46fe4707910719c17168f8e088b9c345952b2ef5b"
         },

--- a/GeneralStateTests/stEWASMTests/callValueExceedsBalance.json
+++ b/GeneralStateTests/stEWASMTests/callValueExceedsBalance.json
@@ -2,8 +2,8 @@
     "callValueExceedsBalance" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callValueExceedsBalanceFiller.yml",
             "sourceHash" : "e055f520b43bb085ff102b265e45afb1643930f78854ae50b2d5469c57791b2b"
         },

--- a/GeneralStateTests/stEWASMTests/callValueInStaticMode.json
+++ b/GeneralStateTests/stEWASMTests/callValueInStaticMode.json
@@ -2,8 +2,8 @@
     "callValueInStaticMode" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callValueInStaticModeFiller.yml",
             "sourceHash" : "6638a339aff13489e28d8c61d5118965c4e3b0eced3aafd186307a22e1389fc8"
         },

--- a/GeneralStateTests/stEWASMTests/callValueNonExistingAcct.json
+++ b/GeneralStateTests/stEWASMTests/callValueNonExistingAcct.json
@@ -2,8 +2,8 @@
     "callValueNonExistingAcct" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callValueNonExistingAcctFiller.yml",
             "sourceHash" : "1fd5429f326f169862b76cdc4c314903a5492700ad4d848646de7566399e1e90"
         },

--- a/GeneralStateTests/stEWASMTests/callVeryLong.json
+++ b/GeneralStateTests/stEWASMTests/callVeryLong.json
@@ -2,8 +2,8 @@
     "callVeryLong" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/callVeryLongFiller.yml",
             "sourceHash" : "4a162e6f4b8e00782bb2810488a7cce28b4bf28a7f75b2e3c11185dc400d7738"
         },

--- a/GeneralStateTests/stEWASMTests/codeCopy.json
+++ b/GeneralStateTests/stEWASMTests/codeCopy.json
@@ -2,8 +2,8 @@
     "codeCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/codeCopyFiller.yml",
             "sourceHash" : "67b259d1cb0bb9bf92b4022b65900039827b6bed415cb4a43a8ce8794042bf6b"
         },

--- a/GeneralStateTests/stEWASMTests/codeCopyFullyOOB.json
+++ b/GeneralStateTests/stEWASMTests/codeCopyFullyOOB.json
@@ -2,8 +2,8 @@
     "codeCopyFullyOOB" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/codeCopyFullyOOBFiller.yml",
             "sourceHash" : "ad5f0236404d02f8515187297e3b076da141d9a32bc5a8e9fdeda3bc2fb413ca"
         },

--- a/GeneralStateTests/stEWASMTests/codeCopyPartiallyOOB.json
+++ b/GeneralStateTests/stEWASMTests/codeCopyPartiallyOOB.json
@@ -2,8 +2,8 @@
     "codeCopyPartiallyOOB" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/codeCopyPartiallyOOBFiller.yml",
             "sourceHash" : "45c7fa3da94a3a7996a0b05b05896d3249f6f8c64fd9001b842eceb62c26a8bd"
         },

--- a/GeneralStateTests/stEWASMTests/codeSizeGreaterThanMax.json
+++ b/GeneralStateTests/stEWASMTests/codeSizeGreaterThanMax.json
@@ -2,8 +2,8 @@
     "codeSizeGreaterThanMax" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/codeSizeGreaterThanMaxFiller.yml",
             "sourceHash" : "baa092780206ea9d33323e1c56ca03dd5d8585de7688b0241774ee50e2076fb1"
         },

--- a/GeneralStateTests/stEWASMTests/create.json
+++ b/GeneralStateTests/stEWASMTests/create.json
@@ -2,8 +2,8 @@
     "create" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createFiller.yml",
             "sourceHash" : "222916a002ae62a29aa78b70e14953114132aacb2ecf0c4945ac129e66d3d15b"
         },

--- a/GeneralStateTests/stEWASMTests/createCode.json
+++ b/GeneralStateTests/stEWASMTests/createCode.json
@@ -2,8 +2,8 @@
     "createCode" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createCodeFiller.yml",
             "sourceHash" : "f6720eb35a6c7bce86e840a34ba021af3602bdb7c20c3ad9cc3aabaa19f9093d"
         },

--- a/GeneralStateTests/stEWASMTests/createCodeValue.json
+++ b/GeneralStateTests/stEWASMTests/createCodeValue.json
@@ -2,8 +2,8 @@
     "createCodeValue" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createCodeValueFiller.yml",
             "sourceHash" : "54b9da94e23e1f6e7f42825b1ccba04bfdd64d7ca77939f2f01e0f7377650913"
         },

--- a/GeneralStateTests/stEWASMTests/createCodeWithRevert.json
+++ b/GeneralStateTests/stEWASMTests/createCodeWithRevert.json
@@ -2,8 +2,8 @@
     "createCodeWithRevert" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createCodeWithRevertFiller.yml",
             "sourceHash" : "4696630dfc2699cfa21cfd5eb914238535991cdfbe7acacbac7ab698ead2f4db"
         },

--- a/GeneralStateTests/stEWASMTests/createFail.json
+++ b/GeneralStateTests/stEWASMTests/createFail.json
@@ -2,8 +2,8 @@
     "createFail" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createFailFiller.yml",
             "sourceHash" : "321695a3a9c18790a4d9a95f96c63ed000810f300e6207b22affc6a1834efb75"
         },

--- a/GeneralStateTests/stEWASMTests/createFromTransaction.json
+++ b/GeneralStateTests/stEWASMTests/createFromTransaction.json
@@ -2,8 +2,8 @@
     "createFromTransaction" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createFromTransactionFiller.yml",
             "sourceHash" : "7aef88a4243642ecea965192b57d3220d953545c98b307d07b8456bf193c6e96"
         },

--- a/GeneralStateTests/stEWASMTests/createFromTransactionExceedGasLimit.json
+++ b/GeneralStateTests/stEWASMTests/createFromTransactionExceedGasLimit.json
@@ -2,8 +2,8 @@
     "createFromTransactionExceedGasLimit" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createFromTransactionExceedGasLimitFiller.yml",
             "sourceHash" : "448716f2c36c36a4bdc2b16d2ecfb20cc0a620c805970524290447b7471bd6a8"
         },

--- a/GeneralStateTests/stEWASMTests/createFromTransactionReturnRandomBytes.json
+++ b/GeneralStateTests/stEWASMTests/createFromTransactionReturnRandomBytes.json
@@ -2,8 +2,8 @@
     "createFromTransactionReturnRandomBytes" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createFromTransactionReturnRandomBytesFiller.yml",
             "sourceHash" : "1622a93498219d6a58289362c15e81908ac6bcd408580f766d165647830ef0de"
         },

--- a/GeneralStateTests/stEWASMTests/createFromTransactionReturnTwoBytes.json
+++ b/GeneralStateTests/stEWASMTests/createFromTransactionReturnTwoBytes.json
@@ -2,8 +2,8 @@
     "createFromTransactionReturnTwoBytes" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createFromTransactionReturnTwoBytesFiller.yml",
             "sourceHash" : "4d90d68f2a8c1387ecef2c5edca353ada9c65a7bfbe1f5eaf712d1b8238e5689"
         },

--- a/GeneralStateTests/stEWASMTests/createFromTransactionReturnZeroBytes.json
+++ b/GeneralStateTests/stEWASMTests/createFromTransactionReturnZeroBytes.json
@@ -2,8 +2,8 @@
     "createFromTransactionReturnZeroBytes" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createFromTransactionReturnZeroBytesFiller.yml",
             "sourceHash" : "ad828396e53217534d713f731a361fabd31c16210d33d99ec7a42688e2f0ce3c"
         },

--- a/GeneralStateTests/stEWASMTests/createNonzero.json
+++ b/GeneralStateTests/stEWASMTests/createNonzero.json
@@ -2,8 +2,8 @@
     "createNonzero" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createNonzeroFiller.yml",
             "sourceHash" : "eee4bc94fea3aee895e20806c235530575b6d5650d951c01a030788abb4b9340"
         },

--- a/GeneralStateTests/stEWASMTests/createNotEnoughBalance.json
+++ b/GeneralStateTests/stEWASMTests/createNotEnoughBalance.json
@@ -2,8 +2,8 @@
     "createNotEnoughBalance" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createNotEnoughBalanceFiller.yml",
             "sourceHash" : "45ff0b31b3b2165dac55967cff4d3664e2ffab4c4a0f307aa577ff5386b5c198"
         },

--- a/GeneralStateTests/stEWASMTests/createOOB1.json
+++ b/GeneralStateTests/stEWASMTests/createOOB1.json
@@ -2,8 +2,8 @@
     "createOOB1" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createOOB1Filler.yml",
             "sourceHash" : "9c24c921070ea46e35ad69c10c967dede6a7d1a6436eb4a62775bee1473ac52a"
         },

--- a/GeneralStateTests/stEWASMTests/createOOB2.json
+++ b/GeneralStateTests/stEWASMTests/createOOB2.json
@@ -2,8 +2,8 @@
     "createOOB2" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createOOB2Filler.yml",
             "sourceHash" : "789683760b57b0ee77fe484267c4077519f508c6da350a7f31f224d76770faa7"
         },

--- a/GeneralStateTests/stEWASMTests/createOOB3.json
+++ b/GeneralStateTests/stEWASMTests/createOOB3.json
@@ -2,8 +2,8 @@
     "createOOB3" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createOOB3Filler.yml",
             "sourceHash" : "965c0050d573337f6e49555e08207840b3e3d9a07b836454ab86d9a3ac04913a"
         },

--- a/GeneralStateTests/stEWASMTests/createReturnEmptyData.json
+++ b/GeneralStateTests/stEWASMTests/createReturnEmptyData.json
@@ -2,8 +2,8 @@
     "createReturnEmptyData" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createReturnEmptyDataFiller.yml",
             "sourceHash" : "a67a290a1f5cdb85cb278b1fb85aefb826aae6f648ff12391b1dd2b852ede8e8"
         },

--- a/GeneralStateTests/stEWASMTests/createValue.json
+++ b/GeneralStateTests/stEWASMTests/createValue.json
@@ -2,8 +2,8 @@
     "createValue" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createValueFiller.yml",
             "sourceHash" : "c12142821c200e2779979ede16913ce3f8a90b849c9a2ee57e53c4b224a00514"
         },

--- a/GeneralStateTests/stEWASMTests/createVeryLong.json
+++ b/GeneralStateTests/stEWASMTests/createVeryLong.json
@@ -2,8 +2,8 @@
     "createVeryLong" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/createVeryLongFiller.yml",
             "sourceHash" : "afa0c1a6bf5caf54e924b4bb123a8744d0cecd8262560f149361ca1749446dc0"
         },

--- a/GeneralStateTests/stEWASMTests/deepInvalidMemoryAccess.json
+++ b/GeneralStateTests/stEWASMTests/deepInvalidMemoryAccess.json
@@ -2,8 +2,8 @@
     "deepInvalidMemoryAccess" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/deepInvalidMemoryAccessFiller.yml",
             "sourceHash" : "801bcfdef154ad432ec72095b417788659956cdaf5d3ba73c28ed6cab972109a"
         },

--- a/GeneralStateTests/stEWASMTests/ecAddCallDataCopy.json
+++ b/GeneralStateTests/stEWASMTests/ecAddCallDataCopy.json
@@ -2,8 +2,8 @@
     "ecAddCallDataCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/ecAddCallDataCopyFiller.yml",
             "sourceHash" : "7675a3391b7547bae0d65db0422bfa6649128638061d2938388b4a0a1e14d5b1"
         },

--- a/GeneralStateTests/stEWASMTests/extCodeCopy.json
+++ b/GeneralStateTests/stEWASMTests/extCodeCopy.json
@@ -2,8 +2,8 @@
     "extCodeCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/extCodeCopyFiller.yml",
             "sourceHash" : "2b28db84ba9e9bb3949980eada55e7b16999e192e3225a67feb63acf3107f115"
         },

--- a/GeneralStateTests/stEWASMTests/extCodeCopyFullyOOB.json
+++ b/GeneralStateTests/stEWASMTests/extCodeCopyFullyOOB.json
@@ -2,8 +2,8 @@
     "extCodeCopyFullyOOB" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/extCodeCopyFullyOOBFiller.yml",
             "sourceHash" : "29cebb8e3905b85e7b60a3b203a384d4526e1e720f5cd8c785e28187d5ea1b04"
         },

--- a/GeneralStateTests/stEWASMTests/extCodeCopyPartiallyOOB.json
+++ b/GeneralStateTests/stEWASMTests/extCodeCopyPartiallyOOB.json
@@ -2,8 +2,8 @@
     "extCodeCopyPartiallyOOB" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/extCodeCopyPartiallyOOBFiller.yml",
             "sourceHash" : "994ac0cd741d746ea6cff4f94a5e5af3b651d90ad9eb60cc9a7f70199f22cb49"
         },

--- a/GeneralStateTests/stEWASMTests/getAddress.json
+++ b/GeneralStateTests/stEWASMTests/getAddress.json
@@ -2,8 +2,8 @@
     "getAddress" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getAddressFiller.yml",
             "sourceHash" : "f4eadf547ce7959dfda9d1a1de40d6205182e5050fac7d1b815a9ae052c6db2a"
         },

--- a/GeneralStateTests/stEWASMTests/getAddressRust.json
+++ b/GeneralStateTests/stEWASMTests/getAddressRust.json
@@ -2,8 +2,8 @@
     "getAddressRust" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getAddressRustFiller.yml",
             "sourceHash" : "f180d94bd0b0fc443981fe090fd50a8297b78d2860a9c03f8c6ba96cd91aec75"
         },

--- a/GeneralStateTests/stEWASMTests/getBalanceExt.json
+++ b/GeneralStateTests/stEWASMTests/getBalanceExt.json
@@ -2,8 +2,8 @@
     "getBalanceExt" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBalanceExtFiller.yml",
             "sourceHash" : "1e492cd2db23b3afd5de10e8cc72532e59d0ddfca44e37ef84d4d3905dfc691f"
         },

--- a/GeneralStateTests/stEWASMTests/getBlockCoinbase.json
+++ b/GeneralStateTests/stEWASMTests/getBlockCoinbase.json
@@ -2,8 +2,8 @@
     "getBlockCoinbase" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBlockCoinbaseFiller.yml",
             "sourceHash" : "36b4f346518c0f607f0da2daf7f91d21ed1d7eb4884b1ddbb790416bac7da4b3"
         },

--- a/GeneralStateTests/stEWASMTests/getBlockDifficulty.json
+++ b/GeneralStateTests/stEWASMTests/getBlockDifficulty.json
@@ -2,8 +2,8 @@
     "getBlockDifficulty" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBlockDifficultyFiller.yml",
             "sourceHash" : "093cab21c21db25ffbc82566c74389dddd2c3e0693fd8eb5abde3b87a1fdc2a5"
         },

--- a/GeneralStateTests/stEWASMTests/getBlockGasLimit.json
+++ b/GeneralStateTests/stEWASMTests/getBlockGasLimit.json
@@ -2,8 +2,8 @@
     "getBlockGasLimit" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBlockGasLimitFiller.yml",
             "sourceHash" : "eb368c416857d32078e9d44958c4ceb67c172f5b12240e02ca2838bed2637889"
         },

--- a/GeneralStateTests/stEWASMTests/getBlockHash.json
+++ b/GeneralStateTests/stEWASMTests/getBlockHash.json
@@ -2,8 +2,8 @@
     "getBlockHash" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBlockHashFiller.yml",
             "sourceHash" : "bc68fcbc6fedf259313a49f66db7a07ad984021464fd5594c5a03b39caaad0c1"
         },

--- a/GeneralStateTests/stEWASMTests/getBlockHashFailure.json
+++ b/GeneralStateTests/stEWASMTests/getBlockHashFailure.json
@@ -2,8 +2,8 @@
     "getBlockHashFailure" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBlockHashFailureFiller.yml",
             "sourceHash" : "becb329b2b31388872c156f924ddd1a4b032b3d3fa4ff883005381dddcc72bbb"
         },

--- a/GeneralStateTests/stEWASMTests/getBlockHashOOB.json
+++ b/GeneralStateTests/stEWASMTests/getBlockHashOOB.json
@@ -2,8 +2,8 @@
     "getBlockHashOOB" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBlockHashOOBFiller.yml",
             "sourceHash" : "c24b99bef86da6bfa7cf3f29355b46dd25a3296b26faea17920f9c5c1780da3c"
         },

--- a/GeneralStateTests/stEWASMTests/getBlockNumber.json
+++ b/GeneralStateTests/stEWASMTests/getBlockNumber.json
@@ -2,8 +2,8 @@
     "getBlockNumber" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBlockNumberFiller.yml",
             "sourceHash" : "91d96c77a99e45294973cf77fbe92a6b08caf6bbc57f48433a20e6a623298a8c"
         },

--- a/GeneralStateTests/stEWASMTests/getBlockNumber002.json
+++ b/GeneralStateTests/stEWASMTests/getBlockNumber002.json
@@ -2,8 +2,8 @@
     "getBlockNumber002" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBlockNumber002Filler.yml",
             "sourceHash" : "f37cf16d440502f996c682d4c01e236bbdeeb99e3621c2bca6b6dde5594ecef4"
         },

--- a/GeneralStateTests/stEWASMTests/getBlockTimestamp.json
+++ b/GeneralStateTests/stEWASMTests/getBlockTimestamp.json
@@ -2,8 +2,8 @@
     "getBlockTimestamp" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getBlockTimestampFiller.yml",
             "sourceHash" : "7ee25254d4ca9bca95583653743558dcbea18c9ef77c639d8507f954040c4bf8"
         },

--- a/GeneralStateTests/stEWASMTests/getCallDataSize.json
+++ b/GeneralStateTests/stEWASMTests/getCallDataSize.json
@@ -2,8 +2,8 @@
     "getCallDataSize" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getCallDataSizeFiller.yml",
             "sourceHash" : "5a2c2e4830a064f98d78ef8be27a9a5f5216bb827350cb9b1277f1a12130605e"
         },

--- a/GeneralStateTests/stEWASMTests/getCallDataSizeInRust.json
+++ b/GeneralStateTests/stEWASMTests/getCallDataSizeInRust.json
@@ -2,8 +2,8 @@
     "getCallDataSizeInRust" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getCallDataSizeInRustFiller.yml",
             "sourceHash" : "bedb2f650935889d4f8deda92148a625dc24003202bd68750c9534b61500bffb"
         },

--- a/GeneralStateTests/stEWASMTests/getCallValue.json
+++ b/GeneralStateTests/stEWASMTests/getCallValue.json
@@ -2,8 +2,8 @@
     "getCallValue" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getCallValueFiller.yml",
             "sourceHash" : "58fa10fd1a9fd5a816439b0538dc1e94fdcdeeb350402bfcf22b490dbcc2b918"
         },

--- a/GeneralStateTests/stEWASMTests/getCaller.json
+++ b/GeneralStateTests/stEWASMTests/getCaller.json
@@ -2,8 +2,8 @@
     "getCaller" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getCallerFiller.yml",
             "sourceHash" : "61afbaa4bec68dc3b89a1ce4418f109fed6fc18145fd6481401e0fec1d96ddaf"
         },

--- a/GeneralStateTests/stEWASMTests/getCodeSize.json
+++ b/GeneralStateTests/stEWASMTests/getCodeSize.json
@@ -2,8 +2,8 @@
     "getCodeSize" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getCodeSizeFiller.yml",
             "sourceHash" : "85a9f73458977fbaaf55ee7087530c38f5fbd7c8606b76d16becac439a200429"
         },

--- a/GeneralStateTests/stEWASMTests/getExternalBalance.json
+++ b/GeneralStateTests/stEWASMTests/getExternalBalance.json
@@ -2,8 +2,8 @@
     "getExternalBalance" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getExternalBalanceFiller.yml",
             "sourceHash" : "e78476eaa782b2ea069b424312de37e64f17400629e34f516dd15245f2337401"
         },

--- a/GeneralStateTests/stEWASMTests/getExternalCodeSize.json
+++ b/GeneralStateTests/stEWASMTests/getExternalCodeSize.json
@@ -2,8 +2,8 @@
     "getExternalCodeSize" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getExternalCodeSizeFiller.yml",
             "sourceHash" : "7c93ac97443a8da755d3ab5eeb7147bc00f5cf31ff81bf06d7d33691afc78f53"
         },

--- a/GeneralStateTests/stEWASMTests/getGasLeft.json
+++ b/GeneralStateTests/stEWASMTests/getGasLeft.json
@@ -2,8 +2,8 @@
     "getGasLeft" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getGasLeftFiller.yml",
             "sourceHash" : "1421c450153df6e1728872d6480ea0c95bfa25d8e2578500730a95771f553821"
         },

--- a/GeneralStateTests/stEWASMTests/getGasLeftCountUsedGas.json
+++ b/GeneralStateTests/stEWASMTests/getGasLeftCountUsedGas.json
@@ -2,8 +2,8 @@
     "getGasLeftCountUsedGas" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getGasLeftCountUsedGasFiller.yml",
             "sourceHash" : "16517bb51046a12c59cfe2d5e71f8925cf525fb635f8274d6aa28ba0251c3ef1"
         },

--- a/GeneralStateTests/stEWASMTests/getGasLeftUseAllGas.json
+++ b/GeneralStateTests/stEWASMTests/getGasLeftUseAllGas.json
@@ -2,8 +2,8 @@
     "getGasLeftUseAllGas" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getGasLeftUseAllGasFiller.yml",
             "sourceHash" : "35d7f81541f47867cec011b27862b12e1c95edfdcdb888043b05cb628971caa2"
         },

--- a/GeneralStateTests/stEWASMTests/getTxGasPrice.json
+++ b/GeneralStateTests/stEWASMTests/getTxGasPrice.json
@@ -2,8 +2,8 @@
     "getTxGasPrice" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getTxGasPriceFiller.yml",
             "sourceHash" : "d80b701f27ef3e074c6ce8ee993bbf3f0eb69e362272237560ebaaa123420be3"
         },

--- a/GeneralStateTests/stEWASMTests/getTxOrigin.json
+++ b/GeneralStateTests/stEWASMTests/getTxOrigin.json
@@ -2,8 +2,8 @@
     "getTxOrigin" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/getTxOriginFiller.yml",
             "sourceHash" : "fab9d1bdeef50a9ece273c3a8ee1a68f27af689c82fc32eb4d86f4b725a3055b"
         },

--- a/GeneralStateTests/stEWASMTests/initMalformedBytecodeHasStart.json
+++ b/GeneralStateTests/stEWASMTests/initMalformedBytecodeHasStart.json
@@ -2,8 +2,8 @@
     "initMalformedBytecodeHasStart" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/initMalformedBytecodeHasStartFiller.yml",
             "sourceHash" : "9726d9b4753e599e5e5449514e2d61d54837e637b465449b2d3cb987965e32e9"
         },

--- a/GeneralStateTests/stEWASMTests/initMalformedBytecodeHasStartFromTx.json
+++ b/GeneralStateTests/stEWASMTests/initMalformedBytecodeHasStartFromTx.json
@@ -2,8 +2,8 @@
     "initMalformedBytecodeHasStartFromTx" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/initMalformedBytecodeHasStartFromTxFiller.yml",
             "sourceHash" : "5684cf33f6d47f6c66a54052f699024f145cd6aee9377db4b999c764930f19de"
         },

--- a/GeneralStateTests/stEWASMTests/initMalformedBytecodeInvalidMain.json
+++ b/GeneralStateTests/stEWASMTests/initMalformedBytecodeInvalidMain.json
@@ -2,8 +2,8 @@
     "initMalformedBytecodeInvalidMain" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/initMalformedBytecodeInvalidMainFiller.yml",
             "sourceHash" : "ac0cd681ef34897978b8237a7a882d3763464c5ce8f642f4466296ecfa1d2dcd"
         },

--- a/GeneralStateTests/stEWASMTests/initMalformedBytecodeInvalidMainFromTx.json
+++ b/GeneralStateTests/stEWASMTests/initMalformedBytecodeInvalidMainFromTx.json
@@ -2,8 +2,8 @@
     "initMalformedBytecodeInvalidMainFromTx" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/initMalformedBytecodeInvalidMainFromTxFiller.yml",
             "sourceHash" : "14d65c7d7c7a9904dfb03cdf2ab5fa1ae73e1fc249c16411635872e3e7639af7"
         },

--- a/GeneralStateTests/stEWASMTests/initMalformedBytecodeMissingMemoryExport.json
+++ b/GeneralStateTests/stEWASMTests/initMalformedBytecodeMissingMemoryExport.json
@@ -2,8 +2,8 @@
     "initMalformedBytecodeMissingMemoryExport" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/initMalformedBytecodeMissingMemoryExportFiller.yml",
             "sourceHash" : "c38350fc11835d01e56022366c6637579f7ad8fec3d4f97f6ddd24bf8e5e57d0"
         },

--- a/GeneralStateTests/stEWASMTests/initMalformedBytecodeMissingMemoryExportFromTx.json
+++ b/GeneralStateTests/stEWASMTests/initMalformedBytecodeMissingMemoryExportFromTx.json
@@ -2,8 +2,8 @@
     "initMalformedBytecodeMissingMemoryExportFromTx" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/initMalformedBytecodeMissingMemoryExportFromTxFiller.yml",
             "sourceHash" : "24a3802dd41e50951d3838c8b2494062c1b9b99ab5943c5c6729a8c2830c0f82"
         },

--- a/GeneralStateTests/stEWASMTests/initMalformedBytecodeNoMain.json
+++ b/GeneralStateTests/stEWASMTests/initMalformedBytecodeNoMain.json
@@ -2,8 +2,8 @@
     "initMalformedBytecodeNoMain" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/initMalformedBytecodeNoMainFiller.yml",
             "sourceHash" : "b20a1483f99e19386db614817e52b53e837e48f577ae46ac0a2c97b063d716cf"
         },

--- a/GeneralStateTests/stEWASMTests/initMalformedBytecodeNoMainFromTx.json
+++ b/GeneralStateTests/stEWASMTests/initMalformedBytecodeNoMainFromTx.json
@@ -2,8 +2,8 @@
     "initMalformedBytecodeNoMainFromTx" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/initMalformedBytecodeNoMainFromTxFiller.yml",
             "sourceHash" : "238c67935e30679b25f065d80968d10f0c26aebfcebabf95d8fc3fbdacb55cce"
         },

--- a/GeneralStateTests/stEWASMTests/log1Topic.json
+++ b/GeneralStateTests/stEWASMTests/log1Topic.json
@@ -3,7 +3,7 @@
         "_info" : {
             "comment" : "",
             "filledwith" : "testeth 1.6.0",
-            "lllcversion" : "Version: 0.5.0+commit.1d4f565a.Linux.clang",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/log1TopicFiller.yml",
             "sourceHash" : "b01906068f4ff5c82d2fe4a839d14e9f2fbc5a5616a8d41cee1c5f72fccb4795"
         },

--- a/GeneralStateTests/stEWASMTests/logInvalidNumTopics.json
+++ b/GeneralStateTests/stEWASMTests/logInvalidNumTopics.json
@@ -3,7 +3,7 @@
         "_info" : {
             "comment" : "",
             "filledwith" : "testeth 1.6.0",
-            "lllcversion" : "Version: 0.5.0+commit.1d4f565a.Linux.clang",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logInvalidNumTopicsFiller.yml",
             "sourceHash" : "53160f6fdb5bcff64794c0171ff20bf6863a43ac53d3317d632d94dde1a69467"
         },

--- a/GeneralStateTests/stEWASMTests/logInvalidPtr.json
+++ b/GeneralStateTests/stEWASMTests/logInvalidPtr.json
@@ -3,7 +3,7 @@
         "_info" : {
             "comment" : "",
             "filledwith" : "testeth 1.6.0",
-            "lllcversion" : "Version: 0.5.0+commit.1d4f565a.Linux.clang",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logInvalidPtrFiller.yml",
             "sourceHash" : "c58d7b95a9f553b4ba9f190c9ff231fac287c77d2b1bd368fee67b72888f2441"
         },

--- a/GeneralStateTests/stEWASMTests/logOOM.json
+++ b/GeneralStateTests/stEWASMTests/logOOM.json
@@ -3,7 +3,7 @@
         "_info" : {
             "comment" : "",
             "filledwith" : "testeth 1.6.0",
-            "lllcversion" : "Version: 0.5.0+commit.1d4f565a.Linux.clang",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logOOMFiller.yml",
             "sourceHash" : "e2389a8654a4e4fd9f7c10bd9999c97be88bd33a38d5e0b9184d8cb38bc40c40"
         },

--- a/GeneralStateTests/stEWASMTests/logTooManyTopics.json
+++ b/GeneralStateTests/stEWASMTests/logTooManyTopics.json
@@ -2,8 +2,8 @@
     "logTooManyTopics" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logTooManyTopicsFiller.yml",
             "sourceHash" : "036b7128c2878bfe0f96973f7f8727c48a4cd2a0b2ebe94e1e899d2943b7e421"
         },

--- a/GeneralStateTests/stEWASMTests/logTopicVeryLong.json
+++ b/GeneralStateTests/stEWASMTests/logTopicVeryLong.json
@@ -2,8 +2,8 @@
     "logTopicVeryLong" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logTopicVeryLongFiller.yml",
             "sourceHash" : "57d11d667d5d2d91f95612d59f6b7e246c729fbd6be3dddb446822fb179c61e8"
         },

--- a/GeneralStateTests/stEWASMTests/logTopics.json
+++ b/GeneralStateTests/stEWASMTests/logTopics.json
@@ -3,7 +3,7 @@
         "_info" : {
             "comment" : "",
             "filledwith" : "testeth 1.6.0",
-            "lllcversion" : "Version: 0.5.0+commit.1d4f565a.Linux.clang",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logTopicsFiller.yml",
             "sourceHash" : "a33c02fe67b779167ee6fe7f20526cdc2ae33848ecbba97f8a256477dfafa48d"
         },

--- a/GeneralStateTests/stEWASMTests/logTopicsOverflow.json
+++ b/GeneralStateTests/stEWASMTests/logTopicsOverflow.json
@@ -2,8 +2,8 @@
     "logTopicsOverflow" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logTopicsOverflowFiller.yml",
             "sourceHash" : "59bb3fea7607e5347497fa712fe5345cde57681b6c336b9ef00448ae535c4006"
         },

--- a/GeneralStateTests/stEWASMTests/logVeryLong.json
+++ b/GeneralStateTests/stEWASMTests/logVeryLong.json
@@ -2,8 +2,8 @@
     "logVeryLong" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logVeryLongFiller.yml",
             "sourceHash" : "7b527591f53137805df54a597685ed2acf950cfba6072d05925d174489a070a2"
         },

--- a/GeneralStateTests/stEWASMTests/logZeroLengthMemory.json
+++ b/GeneralStateTests/stEWASMTests/logZeroLengthMemory.json
@@ -2,8 +2,8 @@
     "logZeroLengthMemory" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logZeroLengthMemoryFiller.yml",
             "sourceHash" : "26004b9834375cf5652b5327e3fe4c192816d14db829216d9c8dca6f39babb43"
         },

--- a/GeneralStateTests/stEWASMTests/logZeroTopics.json
+++ b/GeneralStateTests/stEWASMTests/logZeroTopics.json
@@ -3,7 +3,7 @@
         "_info" : {
             "comment" : "",
             "filledwith" : "testeth 1.6.0",
-            "lllcversion" : "Version: 0.5.0+commit.1d4f565a.Linux.clang",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/logZeroTopicsFiller.yml",
             "sourceHash" : "7aae502b09d196a7564bd3d0b055579424ea9b007f62305d00aa1926f996dbe9"
         },

--- a/GeneralStateTests/stEWASMTests/malformedBytecodeInvalidPreamble.json
+++ b/GeneralStateTests/stEWASMTests/malformedBytecodeInvalidPreamble.json
@@ -2,8 +2,8 @@
     "malformedBytecodeInvalidPreamble" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedBytecodeInvalidPreambleFiller.yml",
             "sourceHash" : "b405f145cb775352b84aac5ec6a730fbad89b9772ebd28851fd7e3b3aafb6850"
         },

--- a/GeneralStateTests/stEWASMTests/malformedBytecodeInvalidWasm.json
+++ b/GeneralStateTests/stEWASMTests/malformedBytecodeInvalidWasm.json
@@ -2,8 +2,8 @@
     "malformedBytecodeInvalidWasm" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedBytecodeInvalidWasmFiller.yml",
             "sourceHash" : "f8b38f587ef248be202378f4d9a55046e6b5e12e6bb8e4b9dda635183435cebf"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeFourParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeFourParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallCodeFourParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeFourParamsFiller.yml",
             "sourceHash" : "987d2942fc7ddfe629a49175714406a5eb1609846d96d929f6ba387160c3c127"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportCallCodeOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeOneParamFiller.yml",
             "sourceHash" : "23e0e6c9cc81193508bac0ff0383509501cc41b4a88827db2fbd6bd8a6e90f64"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallCodeThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeThreeParamsFiller.yml",
             "sourceHash" : "5838d5aecaeeadbc540c2301f8d8761621b857d3e2a501e511a1b917a91c7f64"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallCodeTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeTwoParamsFiller.yml",
             "sourceHash" : "b979c0cdd2c29316743391975e0ee074ef5f3de4ae37574570331c39da996646"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallCodeZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallCodeZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallCodeZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallCodeZeroParamsFiller.yml",
             "sourceHash" : "fb93133d56ab25daa95545592f3f95750465cf6c474dd66db93a30d940702ba3"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportCallDataCopyOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyOneParamFiller.yml",
             "sourceHash" : "ff29e5b4fb4f420e5c075d31ddcfd34a1363b99393c5dd3a19c205eea7e13e55"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallDataCopyTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyTwoParamsFiller.yml",
             "sourceHash" : "50cc970bb415f3f9e8ebc25be556b2b5388299db6b8fb02ce4d997a89d1931bd"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataCopyZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallDataCopyZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataCopyZeroParamsFiller.yml",
             "sourceHash" : "5803c1fbd4fb30692aefff7abfd518a85f1554545ec8e7abe70e29a32fba9768"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataSizeOneParamNoReturn.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataSizeOneParamNoReturn.json
@@ -2,8 +2,8 @@
     "malformedImportCallDataSizeOneParamNoReturn" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataSizeOneParamNoReturnFiller.yml",
             "sourceHash" : "bef0e55bbac9a75b7d9024f8a02dd4eedee837927a286360bf8db3b537b80216"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDataSizeOneParamWithReturn.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDataSizeOneParamWithReturn.json
@@ -2,8 +2,8 @@
     "malformedImportCallDataSizeOneParamWithReturn" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDataSizeOneParamWithReturnFiller.yml",
             "sourceHash" : "1b6a07c83522cb3e02ce59433a616042fb9bc727dab0603fb1f1a802766e7eaf"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateFiveParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateFiveParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallDelegateFiveParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateFiveParamsFiller.yml",
             "sourceHash" : "eafc6895ce1a9f870a06a2b6b6ef00c2e736e393c73fec55beeb59e1efd22e62"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportCallDelegateOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateOneParamFiller.yml",
             "sourceHash" : "cf0a0db7d8994d35ab6464bceaca003ba1676a5d683e241504f1177b35311861"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallDelegateThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateThreeParamsFiller.yml",
             "sourceHash" : "bb315bf100bbfbd506846322e1dc5ce375ed3549233423303c0ea0782cacf0ec"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallDelegateTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateTwoParamsFiller.yml",
             "sourceHash" : "455984e231a976c16b4abde3953c231d0cd26a5924f142f218efea80843cbe2e"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallDelegateZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallDelegateZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallDelegateZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallDelegateZeroParamsFiller.yml",
             "sourceHash" : "442ac7b45aa2a7c6e7a1a821804f46f384763edc23c14627063f9a0bef715029"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallFourParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallFourParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallFourParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallFourParamsFiller.yml",
             "sourceHash" : "1a5998218261baca2938c7aec43a37c01d9f784e7a8837d0d77c7f9a198a85b5"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportCallOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallOneParamFiller.yml",
             "sourceHash" : "7bc0c0b2d7c8fd8517bb217b982324e70b89b876d7319ee6d642061894e72858"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticFiveParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticFiveParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallStaticFiveParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticFiveParamsFiller.yml",
             "sourceHash" : "d2c30e8222a002abf179ed1067084d91ea2da51d53e755c809cc38747ceb5e7f"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportCallStaticOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticOneParamFiller.yml",
             "sourceHash" : "a1ec9377778ee40d98957cb28e4c8692a6ae6e28425d4f7bf0968fb9f77b2f16"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallStaticThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticThreeParamsFiller.yml",
             "sourceHash" : "85a5a663660bf30fc9a75d1dec28d6d4266d677a0f7f6ebf62d4a17957cd59b1"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallStaticTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticTwoParamsFiller.yml",
             "sourceHash" : "264890ef3114d6fb207a98e79318b1290d4c2962d39cd4357f3b3b39b72dadd3"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallStaticZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallStaticZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallStaticZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallStaticZeroParamsFiller.yml",
             "sourceHash" : "b59d3ad4e77d5e44bc3d21a28361d3a0e63c1de0eba26a919c30cf1d2d8b6c29"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallThreeParamsFiller.yml",
             "sourceHash" : "302354da985677c99a6367ab9114e39c6a3fb031a0dceeed1ed5e8ee4bde4308"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallTwoParamsFiller.yml",
             "sourceHash" : "cc5818fd2177a1a256f9281cee1a393e0e0bc0011be838a61be5f1512d596849"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCallZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCallZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportCallZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6-1+commit.19ad7d95",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCallZeroParamsFiller.yml",
             "sourceHash" : "fbc9d327dcd05e4087dda48045d56156f1a432e77a93dfe2e5325312c20ce430"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCodeCopyFourParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCodeCopyFourParams.json
@@ -2,8 +2,8 @@
     "malformedImportCodeCopyFourParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCodeCopyFourParamsFiller.yml",
             "sourceHash" : "75af714f96c69840c0e1a8b589da1a3f07f8c0a2c480668bebb484ed5afd2bf4"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCodeCopyOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCodeCopyOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportCodeCopyOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCodeCopyOneParamFiller.yml",
             "sourceHash" : "5ca17d786019bf27901f3b1697b1dff163df899eab21b5e78677bc15cca4dd91"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCodeCopyTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCodeCopyTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportCodeCopyTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCodeCopyTwoParamsFiller.yml",
             "sourceHash" : "3c59b491f1b071734c8f867727c0e84180e0a774814f5516094c0c7f25f07d2a"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCodeCopyZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCodeCopyZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportCodeCopyZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCodeCopyZeroParamsFiller.yml",
             "sourceHash" : "5a184f7f037062762523ce212e32851128cef3fabf7669e7a9bd3371fe37f693"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCreateFiveParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCreateFiveParams.json
@@ -2,8 +2,8 @@
     "malformedImportCreateFiveParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCreateFiveParamsFiller.yml",
             "sourceHash" : "53832c1b5756c7797567bcec7608d792d2ef062a3f506d0bd11366445c28b74f"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCreateOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCreateOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportCreateOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCreateOneParamFiller.yml",
             "sourceHash" : "45c0fc26917d07e6af8110ed8c9e8da56f58ba72cb7d458abb3f0e3a5aebde4e"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCreateThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCreateThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportCreateThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCreateThreeParamsFiller.yml",
             "sourceHash" : "c72d77090d28f26f2edab0db06716baeb5992f16dcc49661a3767df760c419cb"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCreateTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCreateTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportCreateTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCreateTwoParamsFiller.yml",
             "sourceHash" : "3fe53e69d6301b4ec7370a9b5f4e2d86673489e3d8cd6cc07ade4a1d142c54af"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportCreateZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportCreateZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportCreateZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportCreateZeroParamsFiller.yml",
             "sourceHash" : "7ddd5d34a0d7d34397c800e4f0930f5d74f529fa8ee591442905607753f683c8"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyFiveParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyFiveParams.json
@@ -2,8 +2,8 @@
     "malformedImportExternalCodeCopyFiveParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportExternalCodeCopyFiveParamsFiller.yml",
             "sourceHash" : "bde06a953f16f3f9003a819698645b74c5867e6dc04faa2b4c76c6e946b33881"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportExternalCodeCopyOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportExternalCodeCopyOneParamFiller.yml",
             "sourceHash" : "97e9f2733d94b87d4cc5785021e042c29dd37f235a94fdfc5d427dfd770b164c"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportExternalCodeCopyThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportExternalCodeCopyThreeParamsFiller.yml",
             "sourceHash" : "a551e36c11bc3e9cb2285b01e46e3e7332b8fcd5c6686bf645e8dd306274d528"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportExternalCodeCopyTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportExternalCodeCopyTwoParamsFiller.yml",
             "sourceHash" : "f12bad6f180ecb36712e648f9a9bbd7df533d69437f043d743816486190442ac"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportExternalCodeCopyZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportExternalCodeCopyZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportExternalCodeCopyZeroParamsFiller.yml",
             "sourceHash" : "742fb74c3c2ec1a8c9350f6bdc942f531958840f557bb547ff02de758df15a4b"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportFinishOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportFinishOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportFinishOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportFinishOneParamFiller.yml",
             "sourceHash" : "4406502e9a1200c97a7af3f38a7f56b3affc9bc4539c6b0a02065a7cb0814289"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportFinishThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportFinishThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportFinishThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportFinishThreeParamsFiller.yml",
             "sourceHash" : "f398e0ad9715b5aeff495d610ce4d5a149c087dc283fdaaeb5e74f2d160a88ff"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportFinishZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportFinishZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportFinishZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportFinishZeroParamsFiller.yml",
             "sourceHash" : "7772c1a62dc61a132e67b719431b0fe1c1db14d398bc86bebb9fc190321eb51a"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetAddressTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetAddressTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetAddressTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetAddressTwoParamsFiller.yml",
             "sourceHash" : "51713f0748a20d14301394b70761e52110138e0002f19ea325d8583502dbfd82"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetAddressZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetAddressZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetAddressZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetAddressZeroParamsFiller.yml",
             "sourceHash" : "6bd33f1445b08c78b7e0dd44f9c7994ee51dd4467bde6bcab186d5867e9f13cc"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBalanceOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBalanceOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportGetBalanceOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBalanceOneParamFiller.yml",
             "sourceHash" : "b2ab8d54f8f558a33705642065cfb6b60b7b0ef67ea249f6518af5f71c2e8831"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBalanceThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBalanceThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetBalanceThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBalanceThreeParamsFiller.yml",
             "sourceHash" : "9d65a5c58b1496d0cf0c5647db78cb3c94cd2116019c6813a76e0aa8ac6f8f5e"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBalanceZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBalanceZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetBalanceZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBalanceZeroParamsFiller.yml",
             "sourceHash" : "c8a8b4342e561867b4b263a23c5f50d779e34f56877ce6bf7cd841bdd880b85b"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockCoinbaseTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockCoinbaseTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockCoinbaseTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockCoinbaseTwoParamsFiller.yml",
             "sourceHash" : "566b9b30e9edc43d8f458ad50cc3e3d79cd3dafd186a68f7928295cc0dcd244e"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockCoinbaseZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockCoinbaseZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockCoinbaseZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockCoinbaseZeroParamsFiller.yml",
             "sourceHash" : "5190fe1222576b054338af9cd2d5a15db90d41a13e1826e134611bf251f7f478"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockDifficultyTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockDifficultyTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockDifficultyTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockDifficultyTwoParamsFiller.yml",
             "sourceHash" : "a41de3135d93dfa3299bf70fc873fcdcbcf7a46b3d10c08d66e4694a5fc19e16"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockDifficultyZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockDifficultyZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockDifficultyZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockDifficultyZeroParamsFiller.yml",
             "sourceHash" : "df708c547886dd2371dd0c10cd0d403fc419f18a7bd0b4ca0eb450861306eb34"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockGasLimitOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockGasLimitOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockGasLimitOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockGasLimitOneParamFiller.yml",
             "sourceHash" : "83579679c35d649d24a58186b66b57463aa5a843c3a763209a8cb9e9f2b33a04"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockHashOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockHashOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockHashOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockHashOneParamFiller.yml",
             "sourceHash" : "15d1624f6364f11ec595325e5166a137915b7e92dc4a369018be9796efbf0bca"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockHashThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockHashThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockHashThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockHashThreeParamsFiller.yml",
             "sourceHash" : "c6cd3a1325a86d55e3be0c0ab578a7d2fa5e6798a754e199d03b49bf41838e7e"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockHashZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockHashZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockHashZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockHashZeroParamsFiller.yml",
             "sourceHash" : "8e68b220172b9a3826434d9a84dbd120991806d7be701465542c81411588feba"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockNumberOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockNumberOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockNumberOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockNumberOneParamFiller.yml",
             "sourceHash" : "854e98834dab9d9adf001320c535f27b45e30688ab90da839f32e9e814eba329"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetBlockTimestampOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetBlockTimestampOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportGetBlockTimestampOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetBlockTimestampOneParamFiller.yml",
             "sourceHash" : "7306ae0d14396cbb23a6f4f5b0d5a5408d5700f42575274478b49a115024522d"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetCallValueTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetCallValueTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetCallValueTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetCallValueTwoParamsFiller.yml",
             "sourceHash" : "ff06ece8ea55541398697408204686ef864868e6d33c22399231e8bbdf2bb24b"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetCallValueZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetCallValueZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetCallValueZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetCallValueZeroParamsFiller.yml",
             "sourceHash" : "d99c8a501cd7a964d1832bcf5775bbed64da996d998ad890a149e3c3f902e58d"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetCallerTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetCallerTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetCallerTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetCallerTwoParamsFiller.yml",
             "sourceHash" : "15eb6e647ab6455f888ef91832fd29a37b5b74432d6c8d9ef916fb2ebc238fbf"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetCallerZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetCallerZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetCallerZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetCallerZeroParamsFiller.yml",
             "sourceHash" : "129c55ab1f175c5644da7b51804bdabd47e7df53f0466a58cf4280c666203cdc"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetCodeSizeOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetCodeSizeOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportGetCodeSizeOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetCodeSizeOneParamFiller.yml",
             "sourceHash" : "59621485a328c5c56be760b388ea0a5da7b880349d86717b299f828a6e969e15"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetExternalCodeSizeTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetExternalCodeSizeTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetExternalCodeSizeTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetExternalCodeSizeTwoParamsFiller.yml",
             "sourceHash" : "784dc2f8884633a887b4c55e932f17ca78b09da4c085d70604adfdc409d4f6c3"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetExternalCodeSizeZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetExternalCodeSizeZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetExternalCodeSizeZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetExternalCodeSizeZeroParamsFiller.yml",
             "sourceHash" : "ee430883ae60b35c331d5ccc0c0525de955002a5a1fbe658cfcdc7429f708d3f"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetGasLeftOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetGasLeftOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportGetGasLeftOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetGasLeftOneParamFiller.yml",
             "sourceHash" : "29d4d47e79aeacce4db99330fab590112a95b6b719da3fe3216274677c1d3542"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetReturnDataSizeOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetReturnDataSizeOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportGetReturnDataSizeOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetReturnDataSizeOneParamFiller.yml",
             "sourceHash" : "0a7f57b05488fc982b96e92f42708eae5791bca376594f533bb51999e8d6304c"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetTxGasPriceTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetTxGasPriceTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetTxGasPriceTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetTxGasPriceTwoParamsFiller.yml",
             "sourceHash" : "96d8786b1e7ac557fbdc2e9355b6941d57bc8fd3475efe9ba19979abd921cca2"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetTxGasPriceZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetTxGasPriceZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetTxGasPriceZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetTxGasPriceZeroParamsFiller.yml",
             "sourceHash" : "1203ac0f1a9930b2005599cf4921fcd0c8340fe277b8e7d7cfdbe0583587eae6"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetTxOriginTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetTxOriginTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetTxOriginTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetTxOriginTwoParamsFiller.yml",
             "sourceHash" : "7d594a19469eadd15a713360ce21058688ad414a5c7e0d1f99f8944753d858f1"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportGetTxOriginZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportGetTxOriginZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportGetTxOriginZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportGetTxOriginZeroParamsFiller.yml",
             "sourceHash" : "1d43243c03f17aac8f4743e2ddd2a3d83f98483945e8b9c72bc4f8650ff802d3"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportLogEightParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportLogEightParams.json
@@ -2,8 +2,8 @@
     "malformedImportLogEightParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportLogEightParamsFiller.yml",
             "sourceHash" : "1b9bc6ae7e413b0efda8dc47d25d94d98486be1df827bda6ec9538c3a4c6344f"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportLogFiveParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportLogFiveParams.json
@@ -2,8 +2,8 @@
     "malformedImportLogFiveParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportLogFiveParamsFiller.yml",
             "sourceHash" : "566ff160a264ae836682ccfce1cf5754e88cbd7fc61ac7efaffa4c0833056d0e"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportLogFourParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportLogFourParams.json
@@ -2,8 +2,8 @@
     "malformedImportLogFourParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportLogFourParamsFiller.yml",
             "sourceHash" : "8e5b5d181406b71a0a46daa33d109c7a30dbfad3ea1fcdd2d841993cc62a1556"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportLogOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportLogOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportLogOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportLogOneParamFiller.yml",
             "sourceHash" : "0e54f62a06c5501abce748ddd2402215aa7eacfb697e1587adda37b97d00698c"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportLogSixParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportLogSixParams.json
@@ -2,8 +2,8 @@
     "malformedImportLogSixParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportLogSixParamsFiller.yml",
             "sourceHash" : "6d0f04f2ad9cfddd95087705241433f65675dbed503923e828180fa0526beb84"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportLogThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportLogThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportLogThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportLogThreeParamsFiller.yml",
             "sourceHash" : "d79c3c198eccb17bec8b7d2b6d5825fceeaf8d351b174e45734951320cc22f2d"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportLogTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportLogTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportLogTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportLogTwoParamsFiller.yml",
             "sourceHash" : "7a8d8bc7bdba60e55f60f50d0a0b28f89cee4f8d85a58fc8cbe908ec0eb80c5b"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportLogZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportLogZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportLogZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportLogZeroParamsFiller.yml",
             "sourceHash" : "698c74840e7f992d6b98696a509424428613b2b553bda8e7b5c428b30638289d"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyFourParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyFourParams.json
@@ -2,8 +2,8 @@
     "malformedImportReturnDataCopyFourParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyFourParamsFiller.yml",
             "sourceHash" : "2f25a5b949df8f2e4a2956f66ee5c82d759ab55288c260ef100fb8b95c9681b4"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportReturnDataCopyOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyOneParamFiller.yml",
             "sourceHash" : "730f8a19f9220ce7ec6afe76744d7978d023e92450c67aa8abaa443e5692b258"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportReturnDataCopyTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyTwoParamsFiller.yml",
             "sourceHash" : "fb849c5afda13c749b6e0b18b2a81673fc8cc8b9d2b745d4a4678e343817129c"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportReturnDataCopyZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportReturnDataCopyZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportReturnDataCopyZeroParamsFiller.yml",
             "sourceHash" : "9a7d9c96f3ad44358388801e0a5e76c84f0ef79eed5d39931883deb30d3bed84"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportRevertOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportRevertOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportRevertOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertOneParamFiller.yml",
             "sourceHash" : "7bc3da2038353e8ea6f8e88956b4bbd5d00b7b8a86afb164024947859b0cbd77"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportRevertThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportRevertThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportRevertThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertThreeParamsFiller.yml",
             "sourceHash" : "0ebf933b03820eb172e0a810ba78d86288eb384e7738498caec5d425a9c2e116"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportRevertZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportRevertZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportRevertZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportRevertZeroParamsFiller.yml",
             "sourceHash" : "dbd8b3527ee2b79c0f83537a16831308f4f8fe7fb0cecc1e391598f475384f53"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportSelfDestructTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportSelfDestructTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportSelfDestructTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportSelfDestructTwoParamsFiller.yml",
             "sourceHash" : "d1e2904a31d28d0ef2bdaef7eb7c94575bf5010cfb0cc21286f085713ffa3731"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportSelfDestructZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportSelfDestructZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportSelfDestructZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportSelfDestructZeroParamsFiller.yml",
             "sourceHash" : "b0a8a9e3fb67f54b4e7a29a6410554ef36ab68130622699b6e567cfa05e74372"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageLoadOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageLoadOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportStorageLoadOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadOneParamFiller.yml",
             "sourceHash" : "52a8ba6935e4236618997fc0cf60263b45a21085f631335b14c11df2465ca260"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageLoadThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageLoadThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportStorageLoadThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadThreeParamsFiller.yml",
             "sourceHash" : "2942e1babb52ea7ef001efb0cdae063ba56d76c248d5919187d23268b5871df3"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageLoadZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageLoadZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportStorageLoadZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageLoadZeroParamsFiller.yml",
             "sourceHash" : "e3ff6da9c64fd740fdbc2f06ac3aec46ff5f89b0341158a9595ec57f6e27a00a"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageStoreOneParam.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageStoreOneParam.json
@@ -2,8 +2,8 @@
     "malformedImportStorageStoreOneParam" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreOneParamFiller.yml",
             "sourceHash" : "4fa8e9471c74a67c1dca3ad64d8acf1497352e07251faeabc9e749056e496677"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageStoreThreeParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageStoreThreeParams.json
@@ -2,8 +2,8 @@
     "malformedImportStorageStoreThreeParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreThreeParamsFiller.yml",
             "sourceHash" : "11ec858cb9b9e3ba1284fff6f44dccf91eade001e4567562640266a0f213df2f"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportStorageStoreZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportStorageStoreZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportStorageStoreZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportStorageStoreZeroParamsFiller.yml",
             "sourceHash" : "9950f50317b7c2de6a7b735bc7476d175c813086af04574f6505790e7951078a"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportUseGasTwoParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportUseGasTwoParams.json
@@ -2,8 +2,8 @@
     "malformedImportUseGasTwoParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportUseGasTwoParamsFiller.yml",
             "sourceHash" : "7b997f15d0e83b86472fe5eafd9c751e2aa56381f1c065c9398edc8350e07818"
         },

--- a/GeneralStateTests/stEWASMTests/malformedImportUseGasZeroParams.json
+++ b/GeneralStateTests/stEWASMTests/malformedImportUseGasZeroParams.json
@@ -2,8 +2,8 @@
     "malformedImportUseGasZeroParams" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/malformedImportUseGasZeroParamsFiller.yml",
             "sourceHash" : "08ef034da4e81a3e94a36ba5ce0ba6cb954f40a0b6cba2610de6bbf10639fab5"
         },

--- a/GeneralStateTests/stEWASMTests/overwriteData.json
+++ b/GeneralStateTests/stEWASMTests/overwriteData.json
@@ -2,8 +2,8 @@
     "overwriteData" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/overwriteDataFiller.yml",
             "sourceHash" : "423ba7fee2357d9d0c48d6d8e3cbf89f31c52c32772f1c5811e7b254776e8f5c"
         },

--- a/GeneralStateTests/stEWASMTests/returnDataCopy.json
+++ b/GeneralStateTests/stEWASMTests/returnDataCopy.json
@@ -2,8 +2,8 @@
     "returnDataCopy" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/returnDataCopyFiller.yml",
             "sourceHash" : "5fb43c563cb82e236e4b9dfc20e67cb143e4f40fdd22afafb1ab41b7067569ef"
         },

--- a/GeneralStateTests/stEWASMTests/returnDataCopyFullyOOB.json
+++ b/GeneralStateTests/stEWASMTests/returnDataCopyFullyOOB.json
@@ -2,8 +2,8 @@
     "returnDataCopyFullyOOB" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/returnDataCopyFullyOOBFiller.yml",
             "sourceHash" : "8d12b00e7f8b750087bb067ec7e78fd226fb5c0c541fa325e72226962f440995"
         },

--- a/GeneralStateTests/stEWASMTests/returnDataCopyPartiallyOOB.json
+++ b/GeneralStateTests/stEWASMTests/returnDataCopyPartiallyOOB.json
@@ -2,8 +2,8 @@
     "returnDataCopyPartiallyOOB" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/returnDataCopyPartiallyOOBFiller.yml",
             "sourceHash" : "6d76c576c2638ccd1b5d044082173aba4433e3cd43883536c1b90f0b3b7a4181"
         },

--- a/GeneralStateTests/stEWASMTests/returnDataCopyTooLongOOB.json
+++ b/GeneralStateTests/stEWASMTests/returnDataCopyTooLongOOB.json
@@ -2,8 +2,8 @@
     "returnDataCopyTooLongOOB" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/returnDataCopyTooLongOOBFiller.yml",
             "sourceHash" : "5684db6d200100997ea029270f138c982df7aa4b403de6448ae1912e51d994bb"
         },

--- a/GeneralStateTests/stEWASMTests/returnPredefinedData.json
+++ b/GeneralStateTests/stEWASMTests/returnPredefinedData.json
@@ -2,8 +2,8 @@
     "returnPredefinedData" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/returnPredefinedDataFiller.yml",
             "sourceHash" : "d4b67556e7067a8116a5e6e0fd34715e9a74672da40aa9f192ccbe84bb5f25a6"
         },

--- a/GeneralStateTests/stEWASMTests/returnVeryLong.json
+++ b/GeneralStateTests/stEWASMTests/returnVeryLong.json
@@ -2,8 +2,8 @@
     "returnVeryLong" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/returnVeryLongFiller.yml",
             "sourceHash" : "415d3e9e657b516dba3c1ca4e6d921febc43135198f9515de022a55746ed2a08"
         },

--- a/GeneralStateTests/stEWASMTests/revert.json
+++ b/GeneralStateTests/stEWASMTests/revert.json
@@ -2,8 +2,8 @@
     "revert" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/revertFiller.yml",
             "sourceHash" : "bd4897f1a6ad6a9091ada5da562dcec5a257689383f342fe44b3d90c0b60315c"
         },

--- a/GeneralStateTests/stEWASMTests/revertVeryLong.json
+++ b/GeneralStateTests/stEWASMTests/revertVeryLong.json
@@ -2,8 +2,8 @@
     "revertVeryLong" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/revertVeryLongFiller.yml",
             "sourceHash" : "cd9cd6483ee442605723d840733ce22873fdd45d886f38bfbb549f535380d876"
         },

--- a/GeneralStateTests/stEWASMTests/rustStorageStore.json
+++ b/GeneralStateTests/stEWASMTests/rustStorageStore.json
@@ -2,8 +2,8 @@
     "rustStorageStore" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/rustStorageStoreFiller.yml",
             "sourceHash" : "c703274a8acbc558ce22fc9b697a1e80cfebde9cd4ccde2e6617ac026bdaa723"
         },

--- a/GeneralStateTests/stEWASMTests/selfDestruct.json
+++ b/GeneralStateTests/stEWASMTests/selfDestruct.json
@@ -2,8 +2,8 @@
     "selfDestruct" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/selfDestructFiller.yml",
             "sourceHash" : "3f26c128ea585ca4148742393b8441456deef8429ec6ccd8bc905745f12a138b"
         },

--- a/GeneralStateTests/stEWASMTests/selfDestructExistingAccount.json
+++ b/GeneralStateTests/stEWASMTests/selfDestructExistingAccount.json
@@ -2,8 +2,8 @@
     "selfDestructExistingAccount" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/selfDestructExistingAccountFiller.yml",
             "sourceHash" : "1a143bf54a515d4474fa275e667a4017d5bf73ebc21f8965c27676cb78e31268"
         },

--- a/GeneralStateTests/stEWASMTests/selfDestructNonExistingAcct.json
+++ b/GeneralStateTests/stEWASMTests/selfDestructNonExistingAcct.json
@@ -2,8 +2,8 @@
     "selfDestructNonExistingAcct" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/selfDestructNonExistingAcctFiller.yml",
             "sourceHash" : "48bca63c744cb8abb4e679a18f7f5ac0bf65b560d1f3bf80abd42a694bbae959"
         },

--- a/GeneralStateTests/stEWASMTests/storageLoad.json
+++ b/GeneralStateTests/stEWASMTests/storageLoad.json
@@ -2,8 +2,8 @@
     "storageLoad" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/storageLoadFiller.yml",
             "sourceHash" : "11a30562c6d94069ae2c9b28c07c1ec24098c2583ee81189b6bd8c45f6599d7d"
         },

--- a/GeneralStateTests/stEWASMTests/storedMalformedBytecodeHasStart.json
+++ b/GeneralStateTests/stEWASMTests/storedMalformedBytecodeHasStart.json
@@ -2,8 +2,8 @@
     "storedMalformedBytecodeHasStart" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/storedMalformedBytecodeHasStartFiller.yml",
             "sourceHash" : "6d7b4dc01bc1e4a6e5e1b93e82611303a0bf550eef99ef2f300c34e56f10172f"
         },

--- a/GeneralStateTests/stEWASMTests/storedMalformedBytecodeHasStartFromTx.json
+++ b/GeneralStateTests/stEWASMTests/storedMalformedBytecodeHasStartFromTx.json
@@ -2,8 +2,8 @@
     "storedMalformedBytecodeHasStartFromTx" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0.dev2-76+commit.2fd57400",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/storedMalformedBytecodeHasStartFromTxFiller.yml",
             "sourceHash" : "55c46e3c04029dce2bb1104d261f020dbbd02280e1d1924a129f84cd91c710e5"
         },

--- a/GeneralStateTests/stEWASMTests/unreachable.json
+++ b/GeneralStateTests/stEWASMTests/unreachable.json
@@ -2,8 +2,8 @@
     "unreachable" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/unreachableFiller.yml",
             "sourceHash" : "1285cf039bdf8f9b0ce9e3673214f64de37495629de4d37f463bbd2c2035604e"
         },

--- a/GeneralStateTests/stEWASMTests/useGas.json
+++ b/GeneralStateTests/stEWASMTests/useGas.json
@@ -2,8 +2,8 @@
     "useGas" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/useGasFiller.yml",
             "sourceHash" : "0a762786b0f142b99db4a6697e7aee25cc5ccd4e9efe341df65f1c041bbc6419"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeBadVersionFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeBadVersionFromTxIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeBadVersionFromTxIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeBadVersionFromTxIsInvalidFiller.yml",
             "sourceHash" : "99e666d83c3c64df83dd342f55a4f4c1feb1313a59b0b0a49e0cba9b25400e79"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeBadVersionIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeBadVersionIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeBadVersionIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeBadVersionIsInvalidFiller.yml",
             "sourceHash" : "27300a52e28e1f1d9c75de699745cb0ff8738ad19b28d5d8f07b4e3de815059b"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeEmptyInitFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeEmptyInitFromTxIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeEmptyInitFromTxIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeEmptyInitFromTxIsInvalidFiller.yml",
             "sourceHash" : "e7ecb3bba4f5e631ea040d5d74d0e859225b38ef68c0dd559af4af7cd1b07d2a"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeEmptyInitIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeEmptyInitIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeEmptyInitIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeEmptyInitIsInvalidFiller.yml",
             "sourceHash" : "1c207f437896a959c26f12787415f09799de4ec4f03934c532e91185be3772b0"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeInvalidImportFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeInvalidImportFromTxIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeInvalidImportFromTxIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeInvalidImportFromTxIsInvalidFiller.yml",
             "sourceHash" : "24f279fdc092fda913fc5e6e66c8d784a4fab535e0ac8ce84e55d68361cfc785"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeInvalidImportIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeInvalidImportIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeInvalidImportIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeInvalidImportIsInvalidFiller.yml",
             "sourceHash" : "83f7b2d2d535fe1baabfe328d87a49397aac284cdf1c1ea451097d59a97cbadd"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeInvalidNamespaceFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeInvalidNamespaceFromTxIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeInvalidNamespaceFromTxIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeInvalidNamespaceFromTxIsInvalidFiller.yml",
             "sourceHash" : "bfdc22dfbb0f1d2ed592ecd203d295ac6ee972d2c38388967fbe57a7e248a5fb"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeInvalidNamespaceIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeInvalidNamespaceIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeInvalidNamespaceIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeInvalidNamespaceIsInvalidFiller.yml",
             "sourceHash" : "b6269ee12d58819f13f5a88e7f360e72be8e5b87b96154545cd593de1131c0f3"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionFromTxIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeMissingVersionFromTxIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionFromTxIsInvalidFiller.yml",
             "sourceHash" : "fab05693fcc369d954faa824080bba9f386efbbd8f983f06be0755b210c6160b"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeMissingVersionIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionIsInvalidFiller.yml",
             "sourceHash" : "38323e8521a7af85f4e9ac17b2e0f582c75289c7ebbef808d585a3fcc8d96ca0"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionOneByteFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionOneByteFromTxIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeMissingVersionOneByteFromTxIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionOneByteFromTxIsInvalidFiller.yml",
             "sourceHash" : "03df37f026f45b1f8e9311a62b8bb312139d725fbf3acfa05b3ecf1c22c4cd1a"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionOneByteIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionOneByteIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeMissingVersionOneByteIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionOneByteIsInvalidFiller.yml",
             "sourceHash" : "907cd966284442aaf998081a8f776318d8ea02d1dec3d7ce52ca8c2d0ae3db32"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeMissingVersionTwoBytesFromTxIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.6",
-            "lllcversion" : "Version: 0.5.0-develop.2018.11.8+commit.20481055.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesFromTxIsInvalidFiller.yml",
             "sourceHash" : "83b9a0f72dcf12f298eb2ffec60d576cd74477725309acc37e2ec28be0d71594"
         },

--- a/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionTwoBytesIsInvalid.json
+++ b/GeneralStateTests/stEWASMTests/validateBytecodeMissingVersionTwoBytesIsInvalid.json
@@ -2,8 +2,8 @@
     "validateBytecodeMissingVersionTwoBytesIsInvalid" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/validateBytecodeMissingVersionTwoBytesIsInvalidFiller.yml",
             "sourceHash" : "1d7dae0fb8be006f89e2e9e90c3e4b1f431c79ffe82de388670a4fcf9372b0b4"
         },

--- a/GeneralStateTests/stEWASMTests/wasmDivisionByZero.json
+++ b/GeneralStateTests/stEWASMTests/wasmDivisionByZero.json
@@ -2,8 +2,8 @@
     "wasmDivisionByZero" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/wasmDivisionByZeroFiller.yml",
             "sourceHash" : "d2e9b2acfccd92c9a6ce5bfd6fff620e18df2a585df16e7fb7a2555ccd2dec90"
         },

--- a/GeneralStateTests/stEWASMTests/wasmGrowMemory.json
+++ b/GeneralStateTests/stEWASMTests/wasmGrowMemory.json
@@ -2,8 +2,8 @@
     "wasmGrowMemory" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/wasmGrowMemoryFiller.yml",
             "sourceHash" : "4f4e13cc466e9f8e1f6ad793953ae43f5eadb7d1ef97bc9225cc140881d942d7"
         },

--- a/GeneralStateTests/stEWASMTests/wasmUnreachable.json
+++ b/GeneralStateTests/stEWASMTests/wasmUnreachable.json
@@ -2,8 +2,8 @@
     "wasmUnreachable" : {
         "_info" : {
             "comment" : "",
-            "filledwith" : "testeth 1.5.0-alpha.4",
-            "lllcversion" : "Version: 0.4.20-develop.2017.12.3+commit.4cad0b22.Linux.g++",
+            "filledwith" : "testeth 1.6.0",
+            "lllcversion" : "Version: 0.5.9-develop.2019.5.10+commit.4de75b24.Linux.g++",
             "source" : "src/GeneralStateTestsFiller/stEWASMTests/wasmUnreachableFiller.yml",
             "sourceHash" : "b69c2139eaacc473e46ea40cea68741e9a9f978ab64126c776ca75a6e67f93f4"
         },


### PR DESCRIPTION
closes: https://github.com/ewasm/tests/issues/116

No errors found while refilling with newer testeth and hera versions